### PR TITLE
Fix for yarn format:check following workspaces migration

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Run check
-        run: yarn format:check
+        run: cd ./packages/pancake-uikit && yarn format:check


### PR DESCRIPTION
One of out Github workflows is targeting a command within the uikit package, causing an error in CI:

<img width="696" alt="Screenshot 2021-03-16 at 15 39 43" src="https://user-images.githubusercontent.com/79279477/111337274-dd763180-866d-11eb-9216-a6b8b17c580f.png">

This is a potential fix - CDing into the directory before running the check.