### PR TITLE
chore(tab-menu): Add tab menu to src/index exports

### DIFF
--- a/packages/pancake-uikit/src/index.ts
+++ b/packages/pancake-uikit/src/index.ts
@@ -13,18 +13,19 @@ export * from "./components/Heading";
 export * from "./components/Image";
 export * from "./components/Input";
 export * from "./components/Layouts";
+export * from "./components/Link";
 export * from "./components/NotificationDot";
+export * from "./components/Progress";
 export * from "./components/Radio";
+export * from "./components/Slider";
+export * from "./components/Skeleton";
+export * from "./components/Spinner";
 export * from "./components/Svg";
+export * from "./components/Table";
+export * from "./components/TabMenu";
 export * from "./components/Tag";
 export * from "./components/Text";
-export * from "./components/Link";
-export * from "./components/Progress";
-export * from "./components/Slider";
-export * from "./components/Spinner";
-export * from "./components/Skeleton";
 export * from "./components/Toggle";
-export * from "./components/Table";
 
 // Hooks
 export * from "./hooks";


### PR DESCRIPTION
When I made the `TabMenu` component... I didn't export it, so it can't yet be used 🤦 

This PR adds it to the index exports.