### PR TITLE
fix: Set panel z index to 0 on desktop

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -203,7 +203,7 @@ it("renders correctly", () => {
           class="sc-hiSbYr lltmGV"
         >
           <div
-            class="sc-kfzAmx ijKars"
+            class="sc-kfzAmx kGTKrM"
           >
             <div
               class="sc-crrsfI laFgBV"

--- a/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
@@ -29,6 +29,7 @@ const StyledPanel = styled.div<{ isPushed: boolean; showMenu: boolean }>`
   transform: translate3d(0, 0, 0);
 
   ${({ theme }) => theme.mediaQueries.nav} {
+    z-index: initial;
     border-right: 2px solid rgba(133, 133, 133, 0.1);
     width: ${({ isPushed }) => `${isPushed ? SIDEBAR_WIDTH_FULL : SIDEBAR_WIDTH_REDUCED}px`};
   }


### PR DESCRIPTION
Updated drawer panel z-index to be 11 when its only on mobile.
On desktop, z-index value is initial

This is needed for Tooltip as Tooltip is beneath the drawer panel now.