### PR TITLE
Component - PancakeToggle

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
@@ -135,7 +135,7 @@ it("renders correctly", () => {
 
     .c3 {
       background-color: transparent;
-      color: #1FC7D4;
+      color: #8f80ba;
     }
 
     .c3:hover:not(:disabled):not(:active) {

--- a/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
@@ -1,0 +1,395 @@
+import React from "react";
+import { renderWithTheme } from "../../testHelpers";
+import PancakeToggle from "../../components/PancakeToggle/PancakeToggle";
+
+const handleChange = jest.fn();
+
+it("renders correctly", () => {
+  const { asFragment } = renderWithTheme(<PancakeToggle checked onChange={handleChange} scale="md" />);
+  expect(asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      .c0 {
+      position: relative;
+      display: inline-block;
+    }
+
+    .c0:label:before {
+      content: none;
+    }
+
+    .c0 .pancakes {
+      -webkit-transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
+      transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
+    }
+
+    .c0 .pancake {
+      background: #e27c31;
+      border-radius: 50%;
+      width: 32px;
+      height: 32px;
+      position: absolute;
+      -webkit-transition: 0.4s ease;
+      transition: 0.4s ease;
+      top: 2px;
+      left: 4px;
+      box-shadow: 0 2px 0 2px #fbbe7c;
+    }
+
+    .c0 .pancake:nth-child(1) {
+      background: #FFFFFF;
+      box-shadow: 0 2px 0 2px #BDC2C4;
+    }
+
+    .c0 .pancake:nth-child(2) {
+      left: 0;
+      top: -3px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease 0.2s;
+      transition: 0.2s ease 0.2s;
+    }
+
+    .c0 .pancake:nth-child(3) {
+      top: -8px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease 0.2s;
+      transition: 0.2s ease 0.2s;
+    }
+
+    .c0 .pancake:nth-child(3):before,
+    .c0 .pancake:nth-child(3):after {
+      content: "";
+      position: absolute;
+      background: #ef8927;
+      border-radius: 20px;
+      width: 50%;
+      height: 20%;
+    }
+
+    .c0 .pancake:nth-child(3):before {
+      top: 20px;
+      left: 5px;
+    }
+
+    .c0 .pancake:nth-child(3):after {
+      top: 22px;
+      right: 5px;
+    }
+
+    .c0 .butter {
+      width: 12px;
+      height: 11px;
+      background: #fbdb60;
+      top: 3px;
+      left: 16px;
+      position: absolute;
+      border-radius: 4px;
+      box-shadow: 0 1px 0 1px #d67823;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease;
+      transition: 0.2s ease;
+    }
+
+    .c1 {
+      height: 40px;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      width: 40px;
+    }
+
+    .c1:focus + label {
+      box-shadow: 0px 0px 0px 1px #7645D9,0px 0px 0px 4px rgba(118,69,217,0.6);
+    }
+
+    .c1:checked + label .pancakes {
+      -webkit-transform: translateX(34px);
+      -ms-transform: translateX(34px);
+      transform: translateX(34px);
+    }
+
+    .c1:checked + label .pancake:nth-child(1) {
+      background: #e27c31;
+      box-shadow: 0 2px 0 2px #fbbe7c;
+      -webkit-transition-delay: 0.2s;
+      transition-delay: 0.2s;
+    }
+
+    .c1:checked + label .pancake:nth-child(2) {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.2s;
+      transition-delay: 0.2s;
+    }
+
+    .c1:checked + label .pancake:nth-child(3) {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.4s;
+      transition-delay: 0.4s;
+    }
+
+    .c1:checked + label .butter {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.6s;
+      transition-delay: 0.6s;
+    }
+
+    .c2 {
+      width: 72px;
+      height: 40px;
+      background: #31D0AA;
+      box-shadow: inset 0px 2px 2px -1px rgba(74,74,104,0.1);
+      display: inline-block;
+      border-radius: 50px;
+      position: relative;
+      -webkit-transition: all 0.3s ease;
+      transition: all 0.3s ease;
+      -webkit-transform-origin: 20% center;
+      -ms-transform-origin: 20% center;
+      transform-origin: 20% center;
+      cursor: pointer;
+    }
+
+    <div
+        class="c0"
+        scale="md"
+      >
+        <input
+          checked=""
+          class="c1"
+          id="pancake-toggle"
+          scale="md"
+          type="checkbox"
+        />
+        <label
+          class="c2"
+          for="pancake-toggle"
+          scale="md"
+        >
+          <div
+            class="pancakes"
+          >
+            <div
+              class="pancake"
+            />
+            <div
+              class="pancake"
+            />
+            <div
+              class="pancake"
+            />
+            <div
+              class="butter"
+            />
+          </div>
+        </label>
+      </div>
+    </DocumentFragment>
+  `);
+});
+
+it("renders correctly scale sm", () => {
+  const { asFragment } = renderWithTheme(<PancakeToggle checked onChange={handleChange} scale="sm" />);
+  expect(asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      .c0 {
+      position: relative;
+      display: inline-block;
+    }
+
+    .c0:label:before {
+      content: none;
+    }
+
+    .c0 .pancakes {
+      -webkit-transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
+      transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
+    }
+
+    .c0 .pancake {
+      background: #e27c31;
+      border-radius: 50%;
+      width: 16px;
+      height: 16px;
+      position: absolute;
+      -webkit-transition: 0.4s ease;
+      transition: 0.4s ease;
+      top: 2px;
+      left: 4px;
+      box-shadow: 0 1px 0 1px #fbbe7c;
+    }
+
+    .c0 .pancake:nth-child(1) {
+      background: #FFFFFF;
+      box-shadow: 0 1px 0 1px #BDC2C4;
+    }
+
+    .c0 .pancake:nth-child(2) {
+      left: 0;
+      top: 0px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease 0.2s;
+      transition: 0.2s ease 0.2s;
+    }
+
+    .c0 .pancake:nth-child(3) {
+      top: -3px;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease 0.2s;
+      transition: 0.2s ease 0.2s;
+    }
+
+    .c0 .pancake:nth-child(3):before,
+    .c0 .pancake:nth-child(3):after {
+      content: "";
+      position: absolute;
+      background: #ef8927;
+      border-radius: 20px;
+      width: 50%;
+      height: 20%;
+    }
+
+    .c0 .pancake:nth-child(3):before {
+      top: 10px;
+      left: 2.5px;
+    }
+
+    .c0 .pancake:nth-child(3):after {
+      top: 11px;
+      right: 2.5px;
+    }
+
+    .c0 .butter {
+      width: 6px;
+      height: 5px;
+      background: #fbdb60;
+      top: 3px;
+      left: 10px;
+      position: absolute;
+      border-radius: 2px;
+      box-shadow: 0 0.5px 0 0.5px #d67823;
+      -webkit-transform: scale(0);
+      -ms-transform: scale(0);
+      transform: scale(0);
+      -webkit-transition: 0.2s ease;
+      transition: 0.2s ease;
+    }
+
+    .c1 {
+      height: 40px;
+      left: 0;
+      opacity: 0;
+      position: absolute;
+      top: 0;
+      width: 40px;
+    }
+
+    .c1:focus + label {
+      box-shadow: 0px 0px 0px 1px #7645D9,0px 0px 0px 4px rgba(118,69,217,0.6);
+    }
+
+    .c1:checked + label .pancakes {
+      -webkit-transform: translateX(16px);
+      -ms-transform: translateX(16px);
+      transform: translateX(16px);
+    }
+
+    .c1:checked + label .pancake:nth-child(1) {
+      background: #e27c31;
+      box-shadow: 0 1px 0 1px #fbbe7c;
+      -webkit-transition-delay: 0.2s;
+      transition-delay: 0.2s;
+    }
+
+    .c1:checked + label .pancake:nth-child(2) {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.2s;
+      transition-delay: 0.2s;
+    }
+
+    .c1:checked + label .pancake:nth-child(3) {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.4s;
+      transition-delay: 0.4s;
+    }
+
+    .c1:checked + label .butter {
+      -webkit-transform: scale(1);
+      -ms-transform: scale(1);
+      transform: scale(1);
+      -webkit-transition-delay: 0.6s;
+      transition-delay: 0.6s;
+    }
+
+    .c2 {
+      width: 36px;
+      height: 20px;
+      background: #31D0AA;
+      box-shadow: inset 0px 2px 2px -1px rgba(74,74,104,0.1);
+      display: inline-block;
+      border-radius: 50px;
+      position: relative;
+      -webkit-transition: all 0.3s ease;
+      transition: all 0.3s ease;
+      -webkit-transform-origin: 20% center;
+      -ms-transform-origin: 20% center;
+      transform-origin: 20% center;
+      cursor: pointer;
+    }
+
+    <div
+        class="c0"
+        scale="sm"
+      >
+        <input
+          checked=""
+          class="c1"
+          id="pancake-toggle"
+          scale="sm"
+          type="checkbox"
+        />
+        <label
+          class="c2"
+          for="pancake-toggle"
+          scale="sm"
+        >
+          <div
+            class="pancakes"
+          >
+            <div
+              class="pancake"
+            />
+            <div
+              class="pancake"
+            />
+            <div
+              class="pancake"
+            />
+            <div
+              class="butter"
+            />
+          </div>
+        </label>
+      </div>
+    </DocumentFragment>
+  `);
+});

--- a/packages/pancake-uikit/src/components/PancakeToggle/PancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/PancakeToggle.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { PancakeStack, PancakeInput, PancakeLabel } from "./StyledPancakeToggle";
+import { PancakeToggleProps, scales } from "./types";
+
+const PancakeToggle: React.FC<PancakeToggleProps> = ({ checked, scale = scales.MD, ...props }) => (
+  <PancakeStack scale={scale}>
+    <PancakeInput id={props.id || "pancake-toggle"} scale={scale} type="checkbox" checked={checked} {...props} />
+    <PancakeLabel scale={scale} checked={checked} htmlFor={props.id || "pancake-toggle"}>
+      <div className="pancakes">
+        <div className="pancake" />
+        <div className="pancake" />
+        <div className="pancake" />
+        <div className="butter" />
+      </div>
+    </PancakeLabel>
+  </PancakeStack>
+);
+
+export default PancakeToggle;

--- a/packages/pancake-uikit/src/components/PancakeToggle/PancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/PancakeToggle.tsx
@@ -16,4 +16,8 @@ const PancakeToggle: React.FC<PancakeToggleProps> = ({ checked, scale = scales.M
   </PancakeStack>
 );
 
+PancakeToggle.defaultProps = {
+  scale: scales.MD,
+};
+
 export default PancakeToggle;

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -3,7 +3,7 @@ import { scales, PancakeToggleProps, HandleProps, InputProps, ScaleKeys } from "
 
 const scaleKeyValues = {
   sm: {
-    pancakeSize: "16px", // The size of a pancake
+    pancakeSize: "16px", // The size of a pancake (the handle)
     travelDistance: "16px", // How far pancakes should travel horizontally
     toggleHeight: "20px", // General Height and
     toggleWidth: "36px", // Width of a toggle box

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -71,9 +71,9 @@ export const PancakeStack = styled.div<HandleProps>`
   }
 
   .pancake:nth-child(1) {
-    background: ${({ theme }) => theme.toggle.handleBackground};
+    background: ${({ theme }) => theme.pancakeToggle.handleBackground};
     box-shadow: 0 ${getScale("pancakeThickness")} 0 ${getScale("pancakeThickness")}
-      ${({ theme }) => theme.colors.textDisabled};
+      ${({ theme }) => theme.pancakeToggle.handleShadow};
   }
 
   .pancake:nth-child(2) {

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -131,6 +131,10 @@ export const PancakeInput = styled.input<InputProps>`
   top: 0;
   width: 40px;
 
+  &:focus + label {
+    box-shadow: ${({ theme }) => theme.shadows.focus};
+  }
+
   &:checked + label .pancakes {
     transform: translateX(${getScale("travelDistance")});
   }

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -3,26 +3,26 @@ import { scales, PancakeToggleProps, HandleProps, InputProps, ScaleKeys } from "
 
 const scaleKeyValues = {
   sm: {
-    handleSize: "16px",
-    travelDistance: "16px",
-    toggleHeight: "20px",
-    toggleWidth: "36px",
-    pancakeThickness: "1px",
-    pancakeTwoOffset: "0px",
-    pancakeThreeOffset: "-3px",
-    butterTop: "3px",
+    pancakeSize: "16px", // The size of a pancake
+    travelDistance: "16px", // How far pancakes should travel horizontally
+    toggleHeight: "20px", // General Height and
+    toggleWidth: "36px", // Width of a toggle box
+    pancakeThickness: "1px", // Bottom shadow of a pancake
+    pancakeTwoOffset: "0px", // Pancakes don't look good when they are concentric
+    pancakeThreeOffset: "-3px", // so pancake 2 and 3 are shifted a little bit
+    butterTop: "3px", // Fine adjustments for butter position
     butterLeft: "10px",
-    butterWidth: "6px",
-    butterHeight: "5px",
-    butterThickness: "0.5px",
-    butterRadius: "2px",
-    butterSmearOneTop: "10px",
-    butterSmearOneLeft: "2.5px",
-    butterSmearTwoTop: "11px",
-    butterSmearTwoRight: "2.5px",
+    butterWidth: "6px", // Widht and
+    butterHeight: "5px", // Height of a butter block on top of pancakes
+    butterThickness: "0.5px", // Shadow on the bottom of the butter block
+    butterRadius: "2px", // Rounded corners for the butter
+    butterSmearOneTop: "10px", // There is melted butter
+    butterSmearOneLeft: "2.5px", // next to the butter block
+    butterSmearTwoTop: "11px", // implemented with :before and :after
+    butterSmearTwoRight: "2.5px", // these values adjust the position of it
   },
   md: {
-    handleSize: "32px",
+    pancakeSize: "32px",
     travelDistance: "34px",
     toggleHeight: "40px",
     toggleWidth: "72px",
@@ -61,8 +61,8 @@ export const PancakeStack = styled.div<HandleProps>`
   .pancake {
     background: #e27c31;
     border-radius: 50%;
-    width: ${getScale("handleSize")};
-    height: ${getScale("handleSize")};
+    width: ${getScale("pancakeSize")};
+    height: ${getScale("pancakeSize")};
     position: absolute;
     transition: 0.4s ease;
     top: 2px;

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -1,0 +1,171 @@
+import styled from "styled-components";
+import { scales, PancakeToggleProps, HandleProps, InputProps, ScaleKeys } from "./types";
+
+const scaleKeyValues = {
+  sm: {
+    handleSize: "16px",
+    travelDistance: "16px",
+    toggleHeight: "20px",
+    toggleWidth: "36px",
+    pancakeThickness: "1px",
+    pancakeTwoOffset: "0px",
+    pancakeThreeOffset: "-3px",
+    butterTop: "3px",
+    butterLeft: "10px",
+    butterWidth: "6px",
+    butterHeight: "5px",
+    butterThickness: "0.5px",
+    butterRadius: "2px",
+    butterSmearOneTop: "10px",
+    butterSmearOneLeft: "2.5px",
+    butterSmearTwoTop: "11px",
+    butterSmearTwoRight: "2.5px",
+  },
+  md: {
+    handleSize: "32px",
+    travelDistance: "34px",
+    toggleHeight: "40px",
+    toggleWidth: "72px",
+    pancakeThickness: "2px",
+    pancakeTwoOffset: "-3px",
+    pancakeThreeOffset: "-8px",
+    butterTop: "3px",
+    butterLeft: "16px",
+    butterWidth: "12px",
+    butterHeight: "11px",
+    butterThickness: "1px",
+    butterRadius: "4px",
+    butterSmearOneTop: "20px",
+    butterSmearOneLeft: "5px",
+    butterSmearTwoTop: "22px",
+    butterSmearTwoRight: "5px",
+  },
+};
+
+const getScale = (property: ScaleKeys) => ({ scale = scales.MD }: PancakeToggleProps) => {
+  return scaleKeyValues[scale][property];
+};
+
+export const PancakeStack = styled.div<HandleProps>`
+  position: relative;
+  display: inline-block;
+
+  &:label:before {
+    content: none;
+  }
+
+  .pancakes {
+    transition: 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  }
+
+  .pancake {
+    background: #e27c31;
+    border-radius: 50%;
+    width: ${getScale("handleSize")};
+    height: ${getScale("handleSize")};
+    position: absolute;
+    transition: 0.4s ease;
+    top: 2px;
+    left: 4px;
+    box-shadow: 0 ${getScale("pancakeThickness")} 0 ${getScale("pancakeThickness")} #fbbe7c;
+  }
+
+  .pancake:nth-child(1) {
+    background: ${({ theme }) => theme.toggle.handleBackground};
+    box-shadow: 0 ${getScale("pancakeThickness")} 0 ${getScale("pancakeThickness")}
+      ${({ theme }) => theme.colors.textDisabled};
+  }
+
+  .pancake:nth-child(2) {
+    left: 0;
+    top: ${getScale("pancakeTwoOffset")};
+    transform: scale(0);
+    transition: 0.2s ease 0.2s;
+  }
+
+  .pancake:nth-child(3) {
+    top: ${getScale("pancakeThreeOffset")};
+    transform: scale(0);
+    transition: 0.2s ease 0.2s;
+  }
+
+  .pancake:nth-child(3):before,
+  .pancake:nth-child(3):after {
+    content: "";
+    position: absolute;
+    background: #ef8927;
+    border-radius: 20px;
+    width: 50%;
+    height: 20%;
+  }
+
+  .pancake:nth-child(3):before {
+    top: ${getScale("butterSmearOneTop")};
+    left: ${getScale("butterSmearOneLeft")};
+  }
+
+  .pancake:nth-child(3):after {
+    top: ${getScale("butterSmearTwoTop")};
+    right: ${getScale("butterSmearTwoRight")};
+  }
+
+  .butter {
+    width: ${getScale("butterWidth")};
+    height: ${getScale("butterHeight")};
+    background: #fbdb60;
+    top: ${getScale("butterTop")};
+    left: ${getScale("butterLeft")};
+    position: absolute;
+    border-radius: ${getScale("butterRadius")};
+    box-shadow: 0 ${getScale("butterThickness")} 0 ${getScale("butterThickness")} #d67823;
+    transform: scale(0);
+    transition: 0.2s ease;
+  }
+`;
+
+export const PancakeInput = styled.input<InputProps>`
+  height: 40px;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 40px;
+
+  &:checked + label .pancakes {
+    transform: translateX(${getScale("travelDistance")});
+  }
+
+  &:checked + label .pancake:nth-child(1) {
+    background: #e27c31;
+    box-shadow: 0 ${getScale("pancakeThickness")} 0 ${getScale("pancakeThickness")} #fbbe7c;
+    transition-delay: 0.2s;
+  }
+
+  &:checked + label .pancake:nth-child(2) {
+    transform: scale(1);
+    transition-delay: 0.2s;
+  }
+
+  &:checked + label .pancake:nth-child(3) {
+    transform: scale(1);
+    transition-delay: 0.4s;
+  }
+
+  &:checked + label .butter {
+    transform: scale(1);
+    transition-delay: 0.6s;
+  }
+`;
+
+export const PancakeLabel = styled.label<PancakeToggleProps>`
+  width: ${getScale("toggleWidth")};
+  height: ${getScale("toggleHeight")};
+  background: ${({ theme, checked }) => theme.colors[checked ? "success" : "input"]};
+  box-shadow: ${({ theme }) => theme.shadows.inset};
+  display: inline-block;
+  border-radius: 50px;
+  position: relative;
+  transition: all 0.3s ease;
+  transform-origin: 20% center;
+  cursor: pointer;
+`;

--- a/packages/pancake-uikit/src/components/PancakeToggle/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/index.stories.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import PancakeToggle from "./PancakeToggle";
+
+export default {
+  title: "Components/PancakeToggle",
+  component: PancakeToggle,
+};
+
+export const Default: React.FC = () => {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const toggle = () => setIsChecked(!isChecked);
+
+  return (
+    <>
+      <div style={{ marginBottom: "32px" }}>
+        <PancakeToggle checked={isChecked} onChange={toggle} />
+      </div>
+      <div>
+        <PancakeToggle checked={isChecked} onChange={toggle} scale="sm" />
+      </div>
+    </>
+  );
+};

--- a/packages/pancake-uikit/src/components/PancakeToggle/index.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/index.tsx
@@ -1,0 +1,2 @@
+export { default as PancakeToggle } from "./PancakeToggle";
+export type { PancakeToggleProps, Scales as PancakeToggleScales } from "./types";

--- a/packages/pancake-uikit/src/components/PancakeToggle/theme.ts
+++ b/packages/pancake-uikit/src/components/PancakeToggle/theme.ts
@@ -1,0 +1,12 @@
+import { darkColors, lightColors } from "../../theme/colors";
+import { PancakeToggleTheme } from "./types";
+
+export const light: PancakeToggleTheme = {
+  handleBackground: lightColors.card,
+  handleShadow: lightColors.textDisabled,
+};
+
+export const dark: PancakeToggleTheme = {
+  handleBackground: darkColors.card,
+  handleShadow: darkColors.textDisabled,
+};

--- a/packages/pancake-uikit/src/components/PancakeToggle/types.ts
+++ b/packages/pancake-uikit/src/components/PancakeToggle/types.ts
@@ -1,0 +1,43 @@
+import { InputHTMLAttributes } from "react";
+
+export const scales = {
+  SM: "sm",
+  MD: "md",
+} as const;
+
+export type Scales = typeof scales[keyof typeof scales];
+
+export interface PancakeToggleProps extends InputHTMLAttributes<HTMLInputElement> {
+  scale?: Scales;
+  checked?: boolean;
+}
+
+export interface HandleProps {
+  scale: Scales;
+}
+
+export interface InputProps {
+  scale: Scales;
+}
+
+export const scaleKeys = {
+  handleSize: "handleSize",
+  travelDistance: "travelDistance",
+  toggleHeight: "toggleHeight",
+  toggleWidth: "toggleWidth",
+  pancakeThickness: "pancakeThickness",
+  pancakeTwoOffset: "pancakeTwoOffset",
+  pancakeThreeOffset: "pancakeThreeOffset",
+  butterTop: "butterTop",
+  butterLeft: "butterLeft",
+  butterWidth: "butterWidth",
+  butterHeight: "butterHeight",
+  butterThickness: "butterThickness",
+  butterRadius: "butterRadius",
+  butterSmearOneTop: "butterSmearOneTop",
+  butterSmearOneLeft: "butterSmearOneLeft",
+  butterSmearTwoTop: "butterSmearTwoTop",
+  butterSmearTwoRight: "butterSmearTwoRight",
+} as const;
+
+export type ScaleKeys = typeof scaleKeys[keyof typeof scaleKeys];

--- a/packages/pancake-uikit/src/components/PancakeToggle/types.ts
+++ b/packages/pancake-uikit/src/components/PancakeToggle/types.ts
@@ -26,7 +26,7 @@ export interface InputProps {
 }
 
 export const scaleKeys = {
-  handleSize: "handleSize",
+  pancakeSize: "pancakeSize",
   travelDistance: "travelDistance",
   toggleHeight: "toggleHeight",
   toggleWidth: "toggleWidth",

--- a/packages/pancake-uikit/src/components/PancakeToggle/types.ts
+++ b/packages/pancake-uikit/src/components/PancakeToggle/types.ts
@@ -1,5 +1,10 @@
 import { InputHTMLAttributes } from "react";
 
+export type PancakeToggleTheme = {
+  handleBackground: string;
+  handleShadow: string;
+};
+
 export const scales = {
   SM: "sm",
   MD: "md",

--- a/packages/pancake-uikit/src/index.ts
+++ b/packages/pancake-uikit/src/index.ts
@@ -15,6 +15,7 @@ export * from "./components/Input";
 export * from "./components/Layouts";
 export * from "./components/Link";
 export * from "./components/NotificationDot";
+export * from "./components/PancakeToggle";
 export * from "./components/Progress";
 export * from "./components/Radio";
 export * from "./components/Slider";

--- a/packages/pancake-uikit/src/theme/dark.ts
+++ b/packages/pancake-uikit/src/theme/dark.ts
@@ -1,6 +1,7 @@
 import { DefaultTheme } from "styled-components";
 import { dark as darkAlert } from "../components/Alert/theme";
 import { dark as darkCard } from "../components/Card/theme";
+import { dark as darkPancakeToggle } from "../components/PancakeToggle/theme";
 import { dark as darkRadio } from "../components/Radio/theme";
 import { dark as darkToggle } from "../components/Toggle/theme";
 import { dark as darkNav } from "../widgets/Menu/theme";
@@ -18,6 +19,7 @@ const darkTheme: DefaultTheme = {
   toggle: darkToggle,
   nav: darkNav,
   modal: darkModal,
+  pancakeToggle: darkPancakeToggle,
   radio: darkRadio,
   tooltip: darkTooltip,
 };

--- a/packages/pancake-uikit/src/theme/index.ts
+++ b/packages/pancake-uikit/src/theme/index.ts
@@ -1,5 +1,6 @@
 import { AlertTheme } from "../components/Alert/types";
 import { CardTheme } from "../components/Card/types";
+import { PancakeToggleTheme } from "../components/PancakeToggle/types";
 import { RadioTheme } from "../components/Radio/types";
 import { ToggleTheme } from "../components/Toggle/types";
 import { TooltipTheme } from "../components/Tooltip/types";
@@ -15,6 +16,7 @@ export interface PancakeTheme {
   card: CardTheme;
   nav: NavTheme;
   modal: ModalTheme;
+  pancakeToggle: PancakeToggleTheme;
   radio: RadioTheme;
   toggle: ToggleTheme;
   tooltip: TooltipTheme;

--- a/packages/pancake-uikit/src/theme/light.ts
+++ b/packages/pancake-uikit/src/theme/light.ts
@@ -1,6 +1,7 @@
 import { DefaultTheme } from "styled-components";
 import { light as lightAlert } from "../components/Alert/theme";
 import { light as lightCard } from "../components/Card/theme";
+import { light as lightPancakeToggle } from "../components/PancakeToggle/theme";
 import { light as lightRadio } from "../components/Radio/theme";
 import { light as lightToggle } from "../components/Toggle/theme";
 import { light as lightTooltip } from "../components/Tooltip/theme";
@@ -18,6 +19,7 @@ const lightTheme: DefaultTheme = {
   toggle: lightToggle,
   nav: lightNav,
   modal: lightModal,
+  pancakeToggle: lightPancakeToggle,
   radio: lightRadio,
   tooltip: lightTooltip,
 };


### PR DESCRIPTION
This PR adds PancakeToggle component - very similar to Toggle but with bunch of CSS to show handle as pancakes with butter. [PR 334](https://github.com/pancakeswap/pancake-swap-interface/pull/334) in exchange depends on this.

- [X] Two sizes - `sm` and `md`
- [X] Storybook story

Possible improvements:
- Right now neither `Toggle` nor `PancakeToggle` support responsive array syntax similar (as `styled-system` components), so responsiveness has to be achieved with media queries hook. Seems to be that UIKit components in general don't implement it. It could be done in a general way to plug in responsive array props to components but that's a task for a separate PR (see [this](https://paulie.dev/posts/2020/08/styled-components-responsive-array-syntax/) as reference).

![Screenshot 2021-04-08 at 9 44 46](https://user-images.githubusercontent.com/81824236/113980530-43aa3a80-984f-11eb-85af-3e79b3e6edfb.png)


https://user-images.githubusercontent.com/81824236/113981324-33468f80-9850-11eb-8c7c-cfde0c8e55ab.mp4


