### PR TITLE
chore(breakpoints): Change XL breakpoint to 1200px

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
@@ -542,7 +542,7 @@ it("renders ConnectModal correctly", () => {
               </g>
               <defs>
                 <clippath
-                  id="clip-trustwallet"
+                  id="clip0"
                 >
                   <rect
                     fill="white"

--- a/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
@@ -542,7 +542,7 @@ it("renders ConnectModal correctly", () => {
               </g>
               <defs>
                 <clippath
-                  id="clip0"
+                  id="clip-trustwallet"
                 >
                   <rect
                     fill="white"

--- a/packages/pancake-uikit/src/theme/base.ts
+++ b/packages/pancake-uikit/src/theme/base.ts
@@ -5,7 +5,7 @@ export const breakpointMap: { [key: string]: number } = {
   sm: 576,
   md: 852,
   lg: 968,
-  xl: 1080,
+  xl: 1200,
 };
 
 const breakpoints: Breakpoints = Object.values(breakpointMap).map((breakpoint) => `${breakpoint}px`);


### PR DESCRIPTION
The 'xl' (1080px) breakpoint was hardly used in the FE before the Trading Competition.

@ChefBugs designs now finish at 1200px (Trading Comp & IFO are good examples of this), and so we should match our largest breakpoint to that size. There are Trading Comp styles to be applied at 1200px which do not fit at the current 1080px breakpoint.

I will create a PR pulling in the new uikit version once this is released so I can confirm that it doesn't look like shit