### PR TITLE
fix(modal): Change modal min width to 320px

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
@@ -135,7 +135,7 @@ it("renders correctly", () => {
 
     .c3 {
       background-color: transparent;
-      color: #1FC7D4;
+      color: #8f80ba;
     }
 
     .c3:hover:not(:disabled):not(:active) {

--- a/packages/pancake-uikit/src/__tests__/widgets/modal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/modal.test.tsx
@@ -25,7 +25,7 @@ it("renders correctly", () => {
     }
 
     .c0 {
-      min-width: 360px;
+      min-width: 320px;
     }
 
     .c10 {
@@ -152,7 +152,7 @@ it("renders correctly", () => {
     @media screen and (min-width:370px) {
       .c1 {
         width: auto;
-        min-width: 360px;
+        min-width: 320px;
         max-width: 100%;
       }
     }

--- a/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
@@ -77,7 +77,7 @@ it("renders ConnectModal correctly", () => {
     }
 
     .c0 {
-      min-width: 360px;
+      min-width: 320px;
     }
 
     .c10 {
@@ -322,7 +322,7 @@ it("renders ConnectModal correctly", () => {
     @media screen and (min-width:370px) {
       .c1 {
         width: auto;
-        min-width: 360px;
+        min-width: 320px;
         max-width: 100%;
       }
     }

--- a/packages/pancake-uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/pancake-uikit/src/widgets/Modal/Modal.tsx
@@ -11,7 +11,7 @@ const Modal: React.FC<ModalProps> = ({
   hideCloseButton = false,
   bodyPadding = "24px",
   headerBackground = "transparent",
-  minWidth = "360px",
+  minWidth = "320px",
   ...props
 }) => (
   <ModalContainer minWidth={minWidth} {...props}>


### PR DESCRIPTION
We support devices down to 320px (i.e. iphone 8, or Hops' weird ass iPhone 12 pro).

The default min width for modals should reflect this. (Should it be even lower than 320 to allow for padding?)