### PR TITLE
Feature: Add useTooltip hook

### DIFF
--- a/packages/pancake-uikit/package.json
+++ b/packages/pancake-uikit/package.json
@@ -41,9 +41,11 @@
     "styled-components": "^5.2.3"
   },
   "dependencies": {
+    "@popperjs/core": "^2.9.2",
     "@types/lodash": "^4.14.168",
     "@types/styled-system": "^5.1.10",
     "lodash": "^4.17.20",
+    "react-popper": "^2.2.5",
     "react-transition-group": "^4.4.1",
     "styled-system": "^5.1.5"
   },

--- a/packages/pancake-uikit/src/hooks/index.ts
+++ b/packages/pancake-uikit/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useMatchBreakpoints } from "./useMatchBreakpoints";
 export { default as useParticleBurst } from "./useParticleBurst";
 export { default as useKonamiCheatCode } from "./useKonamiCheatCode";
+export * from "./useTooltip";

--- a/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 export const Arrow = styled.div`
   &,
@@ -18,30 +18,28 @@ export const Arrow = styled.div`
 `;
 
 export const StyledTooltip = styled.div`
-  ${() => css`
-    padding: 16px; // Figma ✔️
-    font-size: 16px; // Figma ✔️ Use pre-defined
-    line-height: 130%; // Figma ✔️ Use pre-defined
-    border-radius: 16px; // Figma ✔️
-    max-width: 320px;
-    background: ${({ theme }) => theme.tooltip.background};
-    color: ${({ theme }) => theme.tooltip.text};
-    box-shadow: ${({ theme }) => theme.tooltip.boxShadow};
+  padding: 16px;
+  font-size: 16px;
+  line-height: 130%;
+  border-radius: 16px;
+  max-width: 320px;
+  background: ${({ theme }) => theme.tooltip.background};
+  color: ${({ theme }) => theme.tooltip.text};
+  box-shadow: ${({ theme }) => theme.tooltip.boxShadow};
 
-    &[data-popper-placement^="top"] > ${Arrow} {
-      bottom: -4px;
-    }
+  &[data-popper-placement^="top"] > ${Arrow} {
+    bottom: -4px;
+  }
 
-    &[data-popper-placement^="bottom"] > ${Arrow} {
-      top: -4px;
-    }
+  &[data-popper-placement^="bottom"] > ${Arrow} {
+    top: -4px;
+  }
 
-    &[data-popper-placement^="left"] > ${Arrow} {
-      right: -4px;
-    }
+  &[data-popper-placement^="left"] > ${Arrow} {
+    right: -4px;
+  }
 
-    &[data-popper-placement^="right"] > ${Arrow} {
-      left: -4px;
-    }
-  `}
+  &[data-popper-placement^="right"] > ${Arrow} {
+    left: -4px;
+  }
 `;

--- a/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
@@ -1,0 +1,47 @@
+import styled, { css } from "styled-components";
+
+export const Arrow = styled.div`
+  &,
+  &::before {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    z-index: -1;
+  }
+
+  &::before {
+    content: "";
+    transform: rotate(45deg);
+    background: ${({ theme }) => theme.tooltip.background};
+  }
+`;
+
+export const StyledTooltip = styled.div`
+  ${() => css`
+    padding: 16px; // Figma ✔️
+    font-size: 16px; // Figma ✔️ Use pre-defined
+    line-height: 130%; // Figma ✔️ Use pre-defined
+    border-radius: 16px; // Figma ✔️
+    max-width: 320px;
+    background: ${({ theme }) => theme.tooltip.background};
+    color: ${({ theme }) => theme.tooltip.text};
+    box-shadow: ${({ theme }) => theme.tooltip.boxShadow};
+
+    &[data-popper-placement^="top"] > ${Arrow} {
+      bottom: -4px;
+    }
+
+    &[data-popper-placement^="bottom"] > ${Arrow} {
+      top: -4px;
+    }
+
+    &[data-popper-placement^="left"] > ${Arrow} {
+      right: -4px;
+    }
+
+    &[data-popper-placement^="right"] > ${Arrow} {
+      left: -4px;
+    }
+  `}
+`;

--- a/packages/pancake-uikit/src/hooks/useTooltip/index.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/index.tsx
@@ -1,0 +1,2 @@
+export { default as useTooltip } from "./useTooltip";
+export type { TooltipRefs, TriggerType } from "./types";

--- a/packages/pancake-uikit/src/hooks/useTooltip/types.ts
+++ b/packages/pancake-uikit/src/hooks/useTooltip/types.ts
@@ -1,0 +1,7 @@
+export interface TooltipRefs {
+  targetRef: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
+  tooltip: React.ReactNode;
+  tooltipVisible: boolean;
+}
+
+export type TriggerType = "click" | "hover" | "focus";

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import styled from "styled-components";
+import Input from "../../components/Input/Input";
+import Text from "../../components/Text/Text";
+import useTooltip from "./useTooltip";
+
+const GridCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ReferenceElement = styled.div`
+  background-color: #1fc7d4;
+  width: 160px;
+  height: 160px;
+  border-radius: 8px;
+`;
+
+const Container = styled.div`
+  padding: 64px 120px;
+  display: grid;
+  grid-template-columns: repeat(3, 200px);
+  grid-template-rows: repeat(4, 200px);
+`;
+
+export default {
+  title: "Hooks/useTooltip",
+};
+
+export const Placement: React.FC = () => {
+  // TOP
+  const { targetRef: targetRefTopStart, tooltip: tooltipTopStart } = useTooltip("top-start", "top-start", "click");
+  const { targetRef: targetRefTop, tooltip: tooltipTop } = useTooltip("top", "top", "click");
+  const { targetRef: targetRefTopEnd, tooltip: tooltipTopEnd } = useTooltip("top-end", "top-end", "click");
+  // LEFT
+  const { targetRef: targetRefLeftStart, tooltip: tooltipLeftStart } = useTooltip("left-start", "left-start", "click");
+  const { targetRef: targetRefLeft, tooltip: tooltipLeft } = useTooltip("left", "left", "click");
+  const { targetRef: targetRefLeftEnd, tooltip: tooltipLeftEnd } = useTooltip("left-end", "left-end", "click");
+  // RIGHT
+  const { targetRef: targetRefRightStart, tooltip: tooltipRightStart } = useTooltip(
+    "right-start",
+    "right-start",
+    "click"
+  );
+  const { targetRef: targetRefRight, tooltip: tooltipRight } = useTooltip("right", "right", "click");
+  const { targetRef: targetRefRightEnd, tooltip: tooltipRightEnd } = useTooltip("right-end", "right-end", "click");
+  // BOTTOM
+  const { targetRef: targetRefBottomStart, tooltip: tooltipBottomStart } = useTooltip(
+    "bottom-start",
+    "bottom-start",
+    "click"
+  );
+  const { targetRef: targetRefBottom, tooltip: tooltipBottom } = useTooltip("bottom", "bottom", "click");
+  const { targetRef: targetRefBottomEnd, tooltip: tooltipBottomEnd } = useTooltip("bottom-end", "bottom-end", "click");
+
+  return (
+    <Container>
+      <GridCell>
+        <ReferenceElement ref={targetRefTopStart} />
+        {tooltipTopStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefTop} />
+        {tooltipTop}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefTopEnd} />
+        {tooltipTopEnd}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeftStart} />
+        {tooltipLeftStart}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRightStart} />
+        {tooltipRightStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeft} />
+        {tooltipLeft}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRight} />
+        {tooltipRight}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefLeftEnd} />
+        {tooltipLeftEnd}
+      </GridCell>
+      <div />
+      <GridCell>
+        <ReferenceElement ref={targetRefRightEnd} />
+        {tooltipRightEnd}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottomStart} />
+        {tooltipBottomStart}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottom} />
+        {tooltipBottom}
+      </GridCell>
+      <GridCell>
+        <ReferenceElement ref={targetRefBottomEnd} />
+        {tooltipBottomEnd}
+      </GridCell>
+      {/* <ReferenceElement ref={targetRefBottom}>
+        <HelpIcon width="48px" />
+      </ReferenceElement>
+      {tooltipBottom}
+      <ReferenceElement ref={targetRefBottomStart}>
+        <HelpIcon width="48px" />
+      </ReferenceElement>
+      {tooltipBottomStart} */}
+    </Container>
+  );
+};
+
+export const Triggers: React.FC = () => {
+  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
+    "You clicked me!",
+    "right",
+    "click"
+  );
+  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
+    "Hovering",
+    "right",
+    "hover"
+  );
+
+  const { tooltipVisible: tooltipVisibleFocus, targetRef: targetRefFocus, tooltip: tooltipFocus } = useTooltip(
+    "You focused me!",
+    "right",
+    "focus"
+  );
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "300px",
+        width: "200px",
+        justifyContent: "space-evenly",
+      }}
+    >
+      <div ref={targetRefClick}>
+        <Input placeholder="click" />
+        {tooltipVisibleClick && tooltipClick}
+      </div>
+      <div ref={targetRefHover}>
+        <Input placeholder="hover" />
+        {tooltipVisibleHover && tooltipHover}
+      </div>
+      <Input ref={targetRefFocus} placeholder="focus" />
+      {tooltipVisibleFocus && tooltipFocus}
+    </div>
+  );
+};
+
+export const FineTuning: React.FC = () => {
+  const { tooltipVisible: tooltipVisibleDefault, targetRef: targetRefDefault, tooltip: tooltipDefault } = useTooltip(
+    "Just default tooltip",
+    "top-start",
+    "hover"
+  );
+  const {
+    tooltipVisible: tooltipVisibleFineTuned,
+    targetRef: targetRefFineTuned,
+    tooltip: tooltipFineTuned,
+  } = useTooltip("Didn't you know that 6 comes before 7?", "top-start", "hover", { right: 221 }, [0, -8]);
+  return (
+    <div style={{ width: "500px", height: "500px" }}>
+      <Text fontSize="20px">Hover over inputs</Text>
+      <Text bold>Default placement</Text>
+      <Input ref={targetRefDefault} value="0x1234567890000" />
+      {tooltipVisibleDefault && tooltipDefault}
+      <Text bold>Fine tuned arrow placement</Text>
+      <Input ref={targetRefFineTuned} value="0x1234576890000" />
+      {tooltipVisibleFineTuned && tooltipFineTuned}
+    </div>
+  );
+};
+
+export const Flipping: React.FC = () => {
+  const { targetRef, tooltip } = useTooltip("All tooltips flip automatically when you scroll", "top", "hover");
+  return (
+    <div style={{ padding: "200px", width: "500px", height: "2000px" }}>
+      <ReferenceElement ref={targetRef} />
+      {tooltip}
+    </div>
+  );
+};

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import Input from "../../components/Input/Input";
 import Text from "../../components/Text/Text";
+import HelpIcon from "../../components/Svg/Icons/Help";
 import useTooltip from "./useTooltip";
 
 const GridCell = styled.div`
@@ -22,6 +23,23 @@ const Container = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 200px);
   grid-template-rows: repeat(4, 200px);
+`;
+
+const ExpandableCard = styled.div`
+  width: 300px;
+  margin: 0 auto;
+  padding: 0 10px;
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: rgba(70, 70, 80, 0.2) 0px 7px 29px 0px;
+`;
+
+const ExpandableHeader = styled.div`
+  height: 40px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export default {
@@ -107,14 +125,6 @@ export const Placement: React.FC = () => {
         <ReferenceElement ref={targetRefBottomEnd} />
         {tooltipBottomEnd}
       </GridCell>
-      {/* <ReferenceElement ref={targetRefBottom}>
-        <HelpIcon width="48px" />
-      </ReferenceElement>
-      {tooltipBottom}
-      <ReferenceElement ref={targetRefBottomStart}>
-        <HelpIcon width="48px" />
-      </ReferenceElement>
-      {tooltipBottomStart} */}
     </Container>
   );
 };
@@ -146,16 +156,75 @@ export const Triggers: React.FC = () => {
         justifyContent: "space-evenly",
       }}
     >
-      <div ref={targetRefClick}>
-        <Input placeholder="click" />
-        {tooltipVisibleClick && tooltipClick}
-      </div>
-      <div ref={targetRefHover}>
-        <Input placeholder="hover" />
-        {tooltipVisibleHover && tooltipHover}
-      </div>
+      <Input ref={targetRefClick} placeholder="click" />
+      {tooltipVisibleClick && tooltipClick}
+      <Input ref={targetRefHover} placeholder="hover" />
+      {tooltipVisibleHover && tooltipHover}
       <Input ref={targetRefFocus} placeholder="focus" />
       {tooltipVisibleFocus && tooltipFocus}
+    </div>
+  );
+};
+
+export const EventPropagationAndMobile: React.FC = () => {
+  const [showExpandedClick, setShowExpandedClick] = useState(false);
+  const [showExpandedHover, setShowExpandedHover] = useState(false);
+  const { tooltipVisible: tooltipVisibleClick, targetRef: targetRefClick, tooltip: tooltipClick } = useTooltip(
+    "You clicked on the help icon but the card did not expand",
+    "right",
+    "click"
+  );
+  const { tooltipVisible: tooltipVisibleHover, targetRef: targetRefHover, tooltip: tooltipHover } = useTooltip(
+    "You hovered over the help icon",
+    "right",
+    "hover"
+  );
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "600px",
+        width: "500px",
+        justifyContent: "space-evenly",
+      }}
+    >
+      <Text>
+        Events do not propagate to other elements in the tree. This helps to not cause unwanted bahaviour like expanding
+        the cards when clicking on the tooltip target.
+      </Text>
+
+      <ExpandableCard onClick={() => setShowExpandedClick(!showExpandedClick)}>
+        <ExpandableHeader>
+          On click {showExpandedClick ? "▴" : "▾"}
+          <span ref={targetRefClick}>
+            <HelpIcon />
+          </span>
+        </ExpandableHeader>
+        {showExpandedClick && (
+          <div style={{ margin: "15px 0" }}>You clicked on the header but not on the help icon inside the header</div>
+        )}
+        {tooltipVisibleClick && tooltipClick}
+      </ExpandableCard>
+      <Text>
+        On touch screen devices hover interactions are also properly handled with `touchstart` and `touchend` events
+        (`mouseenter` and `mouseleave` cause unwated behaviour on some mobile browsers).
+      </Text>
+      <ExpandableCard onClick={() => setShowExpandedHover(!showExpandedHover)}>
+        <ExpandableHeader>
+          On hover {showExpandedHover ? "▴" : "▾"}
+          <span ref={targetRefHover}>
+            <HelpIcon />
+          </span>
+        </ExpandableHeader>
+        {showExpandedHover && (
+          <div style={{ margin: "15px 0" }}>
+            On mobile hovering (or more specifically touching and holding) over the help icon does not trigger expansion
+            of this card
+          </div>
+        )}
+        {tooltipVisibleHover && tooltipHover}
+      </ExpandableCard>
     </div>
   );
 };

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.stories.tsx
@@ -239,7 +239,7 @@ export const FineTuning: React.FC = () => {
     tooltipVisible: tooltipVisibleFineTuned,
     targetRef: targetRefFineTuned,
     tooltip: tooltipFineTuned,
-  } = useTooltip("Didn't you know that 6 comes before 7?", "top-start", "hover", { right: 221 }, [0, -8]);
+  } = useTooltip("Didn't you know that 6 comes before 7?", "top-start", "hover", { right: 221 }, undefined, [0, -8]);
   return (
     <div style={{ width: "500px", height: "500px" }}>
       <Text fontSize="20px">Hover over inputs</Text>
@@ -259,6 +259,47 @@ export const Flipping: React.FC = () => {
     <div style={{ padding: "200px", width: "500px", height: "2000px" }}>
       <ReferenceElement ref={targetRef} />
       {tooltip}
+    </div>
+  );
+};
+
+export const ScreenEdges: React.FC = () => {
+  const { targetRef: targetRefLeft, tooltip: tooltipLeft, tooltipVisible: leftVisible } = useTooltip(
+    "I should not touch the edge of the screen",
+    "top",
+    "click"
+  );
+  const { targetRef: targetRefRight, tooltip: tooltipRight, tooltipVisible: rightVisible } = useTooltip(
+    "I should not touch the edge of the screen",
+    "top",
+    "click"
+  );
+  const { targetRef: targetRefMiddle, tooltip: tooltipMiddle, tooltipVisible: middleVisible } = useTooltip(
+    "I should not touch the edge of the screen",
+    "top",
+    "click"
+  );
+  return (
+    <div style={{ padding: "16px", height: "800px", backgroundColor: "#EEE" }}>
+      <Text>
+        This story can be used to visually tooltip behavior when the target element is positioned close to the screen
+        edge. Open this screen on the phone or in browser with responsive mode. Tooltips should not touch the screen
+        edge.
+      </Text>
+      <div style={{ display: "flex", justifyContent: "space-between", padding: "24px" }}>
+        <span ref={targetRefLeft}>
+          <HelpIcon />
+        </span>
+        {leftVisible && tooltipLeft}
+        <span ref={targetRefMiddle}>
+          <HelpIcon />
+        </span>
+        {middleVisible && tooltipMiddle}
+        <span ref={targetRefRight}>
+          <HelpIcon />
+        </span>
+        {rightVisible && tooltipRight}
+      </div>
     </div>
   );
 };

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Placement, Padding } from "@popperjs/core";
 import { usePopper } from "react-popper";
 import { StyledTooltip, Arrow } from "./StyledTooltip";
@@ -9,12 +9,12 @@ function isTouchDevice() {
 }
 
 const useTooltip = (
-  content: string | React.ReactNode,
+  content: React.ReactNode,
   placement: Placement = "auto",
   trigger: TriggerType = "hover",
   arrowPadding?: Padding,
   tooltipPadding?: Padding,
-  tooltipOffset?: [number | null | undefined, number | null | undefined]
+  tooltipOffset?: [number, number]
 ): TooltipRefs => {
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
   const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null);
@@ -22,32 +22,28 @@ const useTooltip = (
 
   const [visible, setVisible] = useState(false);
 
-  const hideTooltip = React.useCallback((e: Event) => {
+  const hideTooltip = useCallback((e: Event) => {
     e.stopPropagation();
     e.preventDefault();
     setVisible(false);
   }, []);
 
-  const showTooltip = React.useCallback((e: Event) => {
+  const showTooltip = useCallback((e: Event) => {
     e.stopPropagation();
     e.preventDefault();
     setVisible(true);
   }, []);
 
-  const toggleTooltip = React.useCallback(
+  const toggleTooltip = useCallback(
     (e: Event) => {
       e.stopPropagation();
-      if (visible) {
-        setVisible(false);
-      } else {
-        setVisible(true);
-      }
+      setVisible(!visible);
     },
     [visible]
   );
 
   // Trigger = hover
-  React.useEffect(() => {
+  useEffect(() => {
     if (targetElement === null || trigger !== "hover") return undefined;
 
     if (isTouchDevice()) {
@@ -66,7 +62,7 @@ const useTooltip = (
   }, [trigger, targetElement, hideTooltip, showTooltip]);
 
   // Keep tooltip open when cursor moves from the targetElement to the tooltip
-  React.useEffect(() => {
+  useEffect(() => {
     if (tooltipElement === null || trigger !== "hover") return undefined;
 
     tooltipElement.addEventListener("mouseenter", showTooltip);
@@ -78,7 +74,7 @@ const useTooltip = (
   }, [trigger, tooltipElement, hideTooltip, showTooltip]);
 
   // Trigger = click
-  React.useEffect(() => {
+  useEffect(() => {
     if (targetElement === null || trigger !== "click") return undefined;
 
     targetElement.addEventListener("click", toggleTooltip);
@@ -87,7 +83,7 @@ const useTooltip = (
   }, [trigger, targetElement, visible, toggleTooltip]);
 
   // Handle click outside
-  React.useEffect(() => {
+  useEffect(() => {
     if (trigger !== "click") return undefined;
 
     const handleClickOutside = ({ target }: Event) => {
@@ -108,7 +104,7 @@ const useTooltip = (
   }, [trigger, targetElement, tooltipElement]);
 
   // Trigger = focus
-  React.useEffect(() => {
+  useEffect(() => {
     if (targetElement === null || trigger !== "focus") return undefined;
 
     targetElement.addEventListener("focus", showTooltip);

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from "react";
+import { Placement, Padding } from "@popperjs/core";
+import { usePopper } from "react-popper";
+import { StyledTooltip, Arrow } from "./StyledTooltip";
+import { TooltipRefs, TriggerType } from "./types";
+
+// TODO try non-string content
+// TODO check how good auto works
+// TODO: FineTune
+const useTooltip = (
+  content: string | React.ReactNode,
+  placement: Placement = "auto",
+  trigger: TriggerType = "hover",
+  arrowPadding?: Padding,
+  tooltipOffset?: [number | null | undefined, number | null | undefined]
+): TooltipRefs => {
+  const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
+  const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null);
+  const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
+
+  const [visible, setVisible] = useState(false);
+
+  // React guarantess that setState won't change on re-renders
+  // https://reactjs.org/docs/hooks-reference.html#usestate
+  // So it's not necessary to wrap setTooltipVisible in useCallaback
+  // However, I found that plugging () => setTooltipVisible(false) into event listeners
+  // produces decent amount of lag, especially if you click the button rapidly
+  const hideTooltip = React.useCallback(() => {
+    setVisible(false);
+  }, []);
+
+  const showTooltip = React.useCallback(() => {
+    setVisible(true);
+  }, []);
+
+  // TODO perf test if use getLatest()?
+  const toggleTooltip = React.useCallback(() => {
+    if (visible) {
+      hideTooltip();
+    } else {
+      showTooltip();
+    }
+  }, [visible, hideTooltip, showTooltip]);
+
+  // Trigger = hover
+  React.useEffect(() => {
+    if (targetElement === null || trigger !== "hover") return undefined;
+
+    targetElement.addEventListener("mouseenter", showTooltip);
+    targetElement.addEventListener("mouseleave", hideTooltip);
+    return () => {
+      targetElement.removeEventListener("mouseenter", showTooltip);
+      targetElement.removeEventListener("mouseleave", hideTooltip);
+    };
+  }, [trigger, targetElement, hideTooltip, showTooltip]);
+
+  // Keep tooltip open when cursor moves from the targetElement to the tooltip
+  React.useEffect(() => {
+    if (tooltipElement === null || trigger !== "hover") return undefined;
+
+    tooltipElement.addEventListener("mouseenter", showTooltip);
+    tooltipElement.addEventListener("mouseleave", hideTooltip);
+    return () => {
+      tooltipElement.removeEventListener("mouseenter", showTooltip);
+      tooltipElement.removeEventListener("mouseleave", hideTooltip);
+    };
+  }, [trigger, tooltipElement, hideTooltip, showTooltip]);
+
+  // Trigger = click
+  React.useEffect(() => {
+    if (targetElement === null || trigger !== "click") return undefined;
+
+    targetElement.addEventListener("click", toggleTooltip);
+
+    return () => targetElement.removeEventListener("click", toggleTooltip);
+  }, [trigger, targetElement, visible, toggleTooltip]);
+
+  // Handle click outside
+  // TODO: lags? lags seems to go away after useCallback
+  React.useEffect(() => {
+    if (trigger !== "click") return undefined;
+
+    const handleClickOutside = ({ target }: Event) => {
+      if (target instanceof Node) {
+        if (
+          tooltipElement != null &&
+          targetElement != null &&
+          !tooltipElement.contains(target) &&
+          !targetElement.contains(target)
+        ) {
+          setVisible(false);
+        }
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [trigger, targetElement, tooltipElement]);
+
+  // Trigger = focus
+  React.useEffect(() => {
+    if (targetElement === null || trigger !== "focus") return undefined;
+
+    targetElement.addEventListener("focus", showTooltip);
+    targetElement.addEventListener("blur", hideTooltip);
+    return () => {
+      targetElement.removeEventListener("focus", showTooltip);
+      targetElement.removeEventListener("blur", hideTooltip);
+    };
+  }, [trigger, targetElement, showTooltip, hideTooltip]);
+
+  const { styles, attributes } = usePopper(targetElement, tooltipElement, {
+    placement,
+    modifiers: [
+      {
+        name: "arrow",
+        options: { element: arrowElement, padding: arrowPadding || 16 },
+      },
+      { name: "offset", options: { offset: tooltipOffset || [0, 8] } },
+    ],
+  });
+
+  const tooltip = (
+    <StyledTooltip ref={setTooltipElement} style={styles.popper} {...attributes.popper}>
+      {content}
+      <Arrow ref={setArrowElement} style={styles.arrow} />
+    </StyledTooltip>
+  );
+  return {
+    targetRef: setTargetElement,
+    tooltip,
+    tooltipVisible: visible,
+  };
+};
+
+export default useTooltip;

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -8,9 +8,6 @@ function isTouchDevice() {
   return "ontouchstart" in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
 }
 
-// TODO try non-string content
-// TODO check how good auto works
-// TODO: FineTune
 const useTooltip = (
   content: string | React.ReactNode,
   placement: Placement = "auto",
@@ -37,7 +34,6 @@ const useTooltip = (
     setVisible(true);
   }, []);
 
-  // TODO perf test if use getLatest()?
   const toggleTooltip = React.useCallback(
     (e: Event) => {
       e.stopPropagation();
@@ -91,7 +87,6 @@ const useTooltip = (
   }, [trigger, targetElement, visible, toggleTooltip]);
 
   // Handle click outside
-  // TODO: lags? lags seems to go away after useCallback
   React.useEffect(() => {
     if (trigger !== "click") return undefined;
 

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -16,6 +16,7 @@ const useTooltip = (
   placement: Placement = "auto",
   trigger: TriggerType = "hover",
   arrowPadding?: Padding,
+  tooltipPadding?: Padding,
   tooltipOffset?: [number | null | undefined, number | null | undefined]
 ): TooltipRefs => {
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
@@ -123,6 +124,16 @@ const useTooltip = (
     };
   }, [trigger, targetElement, showTooltip, hideTooltip]);
 
+  // On small screens Popper.js tries to squeeze the tooltip to available space without overflowing beyound the edge
+  // of the screen. While it works fine when the element is in the middle of the screen it does not handle well the
+  // cases when the target element is very close to the edge of the screen - no margin is applied between the tooltip
+  // and the screen edge.
+  // preventOverflow mitigates this behaviour, default 16px paddings on left and right solve the problem for all screen sizes
+  // that we support.
+  // Note that in the farm page where there are tooltips very close to the edge of the screen this padding works perfectly
+  // even on the iPhone 5 screen (320px wide), BUT in the storybook with the contrived example ScreenEdges example
+  // iPhone 5 behaves differently overflowing beyound the edge. All paddings are identical so I have no idea why it is,
+  // and fixing that seems like a very bad use of time.
   const { styles, attributes } = usePopper(targetElement, tooltipElement, {
     placement,
     modifiers: [
@@ -131,6 +142,7 @@ const useTooltip = (
         options: { element: arrowElement, padding: arrowPadding || 16 },
       },
       { name: "offset", options: { offset: tooltipOffset || [0, 8] } },
+      { name: "preventOverflow", options: { padding: tooltipPadding || { left: 16, right: 16 } } },
     ],
   });
 

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -141,7 +141,7 @@ const useTooltip = (
         name: "arrow",
         options: { element: arrowElement, padding: arrowPadding || 16 },
       },
-      { name: "offset", options: { offset: tooltipOffset || [0, 8] } },
+      { name: "offset", options: { offset: tooltipOffset || [0, 10] } },
       { name: "preventOverflow", options: { padding: tooltipPadding || { left: 16, right: 16 } } },
     ],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,20 +2429,6 @@
   dependencies:
     "@octokit/openapi-types" "^6.0.0"
 
-"@pancakeswap-libs/eslint-config-pancake@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@pancakeswap-libs/eslint-config-pancake/-/eslint-config-pancake-0.1.0.tgz#109863752b77106bf2721d639c9a17e89002879d"
-  integrity sha512-wJBZike/rd2f/9Vep6yNyA8qqRl7UBW55ppYvPaJa61HjethJ113hcUxWzgbQ35OfnLO5beuTBFqR/rypJ5V/A==
-  dependencies:
-    "@typescript-eslint/eslint-plugin" "^4.7.0"
-    "@typescript-eslint/parser" "^4.7.0"
-    eslint-config-airbnb "^18.2.1"
-    eslint-config-prettier "^6.15.0"
-    eslint-plugin-import "^2.22.1"
-    eslint-plugin-jsx-a11y "^6.4.1"
-    eslint-plugin-react "^7.21.5"
-    eslint-plugin-react-hooks "^4.0.0"
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -2455,7 +2441,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
+"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0", "@popperjs/core@^2.9.2":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
@@ -11861,7 +11847,7 @@ react-popper-tooltip@^3.1.1:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^2.2.4:
+react-popper@^2.2.4, react-popper@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==


### PR DESCRIPTION
This PR adds `useTooltip` hook.

Uses `Popper.js` and `react-popper` to position tooltip.

Minimal example (on hover)
```typescript
const { targetRef, tooltip, tooltipVisible } = useTooltip("Tooltip text", "top");
return (
    <>
      <button ref={targetRef}>hover me</button>
      {tooltipVisible && tooltip}
    </>
);
```

![320](https://user-images.githubusercontent.com/81824236/114273648-9a686d80-9a23-11eb-86d7-668ff5d4aa7a.png)
![375](https://user-images.githubusercontent.com/81824236/114273651-9c323100-9a23-11eb-9b0f-ff33b89e914a.png)
![414](https://user-images.githubusercontent.com/81824236/114273652-9d635e00-9a23-11eb-9097-78488d064e30.png)
![768](https://user-images.githubusercontent.com/81824236/114273653-9dfbf480-9a23-11eb-8228-0c04f89743f1.png)
![990](https://user-images.githubusercontent.com/81824236/114273654-9dfbf480-9a23-11eb-82eb-74caf072fbfd.png)
![darkBig](https://user-images.githubusercontent.com/81824236/114273655-9e948b00-9a23-11eb-8ba9-9a5a00bacde2.png)
![darkSmall](https://user-images.githubusercontent.com/81824236/114273656-9f2d2180-9a23-11eb-8840-ab04c653f07b.png)
