### PR TITLE
fix: Z index breaking language switcher

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -588,7 +588,6 @@ it("renders correctly", () => {
 
     @media screen and (min-width:968px) {
       .c10 {
-        z-index: initial;
         border-right: 2px solid rgba(133,133,133,0.1);
         width: 56px;
       }

--- a/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
@@ -29,7 +29,6 @@ const StyledPanel = styled.div<{ isPushed: boolean; showMenu: boolean }>`
   transform: translate3d(0, 0, 0);
 
   ${({ theme }) => theme.mediaQueries.nav} {
-    z-index: initial;
     border-right: 2px solid rgba(133, 133, 133, 0.1);
     width: ${({ isPushed }) => `${isPushed ? SIDEBAR_WIDTH_FULL : SIDEBAR_WIDTH_REDUCED}px`};
   }


### PR DESCRIPTION
Reverts https://github.com/pancakeswap/pancake-toolkit/pull/45 (GH was complaining when I tried to auto revert)

The language switcher's z-index is messed up