### PR TITLE
fix: Theme config key name

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/tabmenu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/tabmenu.test.tsx
@@ -156,11 +156,11 @@ it("renders correctly", () => {
         >
           <button
             class="c4"
-            color="card"
+            color="backgroundAlt"
           >
             <div
               class="c5"
-              color="card"
+              color="backgroundAlt"
               font-weight="600"
             >
               Item 1

--- a/packages/pancake-uikit/src/components/Alert/theme.ts
+++ b/packages/pancake-uikit/src/components/Alert/theme.ts
@@ -2,9 +2,9 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { AlertTheme } from "./types";
 
 export const light: AlertTheme = {
-  background: lightColors.card,
+  background: lightColors.backgroundAlt,
 };
 
 export const dark: AlertTheme = {
-  background: darkColors.card,
+  background: darkColors.backgroundAlt,
 };

--- a/packages/pancake-uikit/src/components/Card/theme.ts
+++ b/packages/pancake-uikit/src/components/Card/theme.ts
@@ -3,7 +3,7 @@ import { shadows } from "../../theme/base";
 import { CardTheme } from "./types";
 
 export const light: CardTheme = {
-  background: lightColors.card,
+  background: lightColors.backgroundAlt,
   boxShadow: "0px 2px 12px -8px rgba(25, 19, 38, 0.1), 0px 1px 1px rgba(25, 19, 38, 0.05)",
   boxShadowActive: shadows.active,
   boxShadowSuccess: shadows.success,
@@ -17,7 +17,7 @@ export const light: CardTheme = {
 };
 
 export const dark: CardTheme = {
-  background: darkColors.card,
+  background: darkColors.backgroundAlt,
   boxShadow: "0px 2px 12px -8px rgba(25, 19, 38, 0.1), 0px 1px 1px rgba(25, 19, 38, 0.05)",
   boxShadowActive: shadows.active,
   boxShadowSuccess: shadows.success,

--- a/packages/pancake-uikit/src/components/PancakeToggle/theme.ts
+++ b/packages/pancake-uikit/src/components/PancakeToggle/theme.ts
@@ -2,11 +2,11 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { PancakeToggleTheme } from "./types";
 
 export const light: PancakeToggleTheme = {
-  handleBackground: lightColors.card,
+  handleBackground: lightColors.backgroundAlt,
   handleShadow: lightColors.textDisabled,
 };
 
 export const dark: PancakeToggleTheme = {
-  handleBackground: darkColors.card,
+  handleBackground: darkColors.backgroundAlt,
   handleShadow: darkColors.textDisabled,
 };

--- a/packages/pancake-uikit/src/components/Radio/theme.ts
+++ b/packages/pancake-uikit/src/components/Radio/theme.ts
@@ -2,9 +2,9 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { RadioTheme } from "./types";
 
 export const light: RadioTheme = {
-  handleBackground: lightColors.card,
+  handleBackground: lightColors.backgroundAlt,
 };
 
 export const dark: RadioTheme = {
-  handleBackground: darkColors.card,
+  handleBackground: darkColors.backgroundAlt,
 };

--- a/packages/pancake-uikit/src/components/TabMenu/StyledTab.tsx
+++ b/packages/pancake-uikit/src/components/TabMenu/StyledTab.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 interface StyledTabProps {
-  color: "card" | "textSubtle";
+  color: "backgroundAlt" | "textSubtle";
   bgColor: "textSubtle" | "input";
 }
 

--- a/packages/pancake-uikit/src/components/TabMenu/Tab.tsx
+++ b/packages/pancake-uikit/src/components/TabMenu/Tab.tsx
@@ -5,8 +5,12 @@ import { Text } from "../Text";
 
 const Tab: React.FC<TabProps> = ({ isActive = false, onClick, children }) => {
   return (
-    <StyledTab onClick={onClick} bgColor={isActive ? "textSubtle" : "input"} color={isActive ? "card" : "textSubtle"}>
-      <Text fontWeight={600} color={isActive ? "card" : "textSubtle"}>
+    <StyledTab
+      onClick={onClick}
+      bgColor={isActive ? "textSubtle" : "input"}
+      color={isActive ? "backgroundAlt" : "textSubtle"}
+    >
+      <Text fontWeight={600} color={isActive ? "backgroundAlt" : "textSubtle"}>
         {children}
       </Text>
     </StyledTab>

--- a/packages/pancake-uikit/src/components/Toggle/theme.ts
+++ b/packages/pancake-uikit/src/components/Toggle/theme.ts
@@ -2,9 +2,9 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { ToggleTheme } from "./types";
 
 export const light: ToggleTheme = {
-  handleBackground: lightColors.card,
+  handleBackground: lightColors.backgroundAlt,
 };
 
 export const dark: ToggleTheme = {
-  handleBackground: darkColors.card,
+  handleBackground: darkColors.backgroundAlt,
 };

--- a/packages/pancake-uikit/src/components/Tooltip/theme.ts
+++ b/packages/pancake-uikit/src/components/Tooltip/theme.ts
@@ -2,13 +2,13 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { TooltipTheme } from "./types";
 
 export const light: TooltipTheme = {
-  background: darkColors.card,
+  background: darkColors.backgroundAlt,
   text: darkColors.text,
   boxShadow: "0px 0px 2px rgba(0, 0, 0, 0.2), 0px 4px 12px -8px rgba(14, 14, 44, 0.1)",
 };
 
 export const dark: TooltipTheme = {
-  background: lightColors.card,
+  background: lightColors.backgroundAlt,
   text: lightColors.text,
   boxShadow: "0px 0px 2px rgba(0, 0, 0, 0.2), 0px 4px 12px -8px rgba(14, 14, 44, 0.1)",
 };

--- a/packages/pancake-uikit/src/theme/colors.ts
+++ b/packages/pancake-uikit/src/theme/colors.ts
@@ -19,6 +19,7 @@ export const lightColors: Colors = {
   ...brandColors,
   background: "#FAF9FA",
   backgroundDisabled: "#E9EAEB",
+  backgroundAlt: "#FFFFFF",
   contrast: "#191326",
   dropdown: "#F6F6F6",
   invertedContrast: "#FFFFFF",
@@ -29,7 +30,6 @@ export const lightColors: Colors = {
   textDisabled: "#BDC2C4",
   textSubtle: "#8f80ba",
   borderColor: "#E9EAEB",
-  card: "#FFFFFF",
   gradients: {
     bubblegum: "linear-gradient(139.73deg, #E6FDFF 0%, #F3EFFF 100%)",
     cardHeader: "linear-gradient(111.68deg, #F2ECF2 0%, #E8F2F6 100%)",
@@ -44,6 +44,7 @@ export const darkColors: Colors = {
   secondary: "#9A6AFF",
   background: "#100C18",
   backgroundDisabled: "#3c3742",
+  backgroundAlt: "#27262c",
   contrast: "#FFFFFF",
   dropdown: "#1E1D20",
   invertedContrast: "#191326",
@@ -55,7 +56,6 @@ export const darkColors: Colors = {
   textDisabled: "#666171",
   textSubtle: "#A28BD4",
   borderColor: "#524B63",
-  card: "#27262c",
   gradients: {
     bubblegum: "linear-gradient(139.73deg, #313D5C 0%, #3D2A54 100%)",
     cardHeader: "linear-gradient(166.77deg, #3B4155 0%, #3A3045 100%)",

--- a/packages/pancake-uikit/src/theme/types.ts
+++ b/packages/pancake-uikit/src/theme/types.ts
@@ -50,11 +50,11 @@ export type Colors = {
   inputSecondary: string;
   background: string;
   backgroundDisabled: string;
+  backgroundAlt: string;
   text: string;
   textDisabled: string;
   textSubtle: string;
   borderColor: string;
-  card: string;
 
   // Gradients
   gradients: Gradients;

--- a/packages/pancake-uikit/src/widgets/Menu/theme.ts
+++ b/packages/pancake-uikit/src/widgets/Menu/theme.ts
@@ -2,11 +2,11 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { NavTheme } from "./types";
 
 export const light: NavTheme = {
-  background: lightColors.card,
+  background: lightColors.backgroundAlt,
   hover: "#EEEAF4",
 };
 
 export const dark: NavTheme = {
-  background: darkColors.card,
+  background: darkColors.backgroundAlt,
   hover: "#473d5d",
 };

--- a/packages/pancake-uikit/src/widgets/Modal/theme.ts
+++ b/packages/pancake-uikit/src/widgets/Modal/theme.ts
@@ -2,9 +2,9 @@ import { darkColors, lightColors } from "../../theme/colors";
 import { ModalTheme } from "./types";
 
 export const light: ModalTheme = {
-  background: lightColors.card,
+  background: lightColors.backgroundAlt,
 };
 
 export const dark: ModalTheme = {
-  background: darkColors.card,
+  background: darkColors.backgroundAlt,
 };


### PR DESCRIPTION
A `card` color was set in the base theme, and was overrided by the theme object of the the Card component.
Rename this color from `card` to `backgroundAlt` fix the problem.