### PR TITLE
fix: Remove leftover from wallet connect when logout

### DIFF
--- a/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import Button from "../../components/Button/Button";
 import Text from "../../components/Text/Text";
 import LinkExternal from "../../components/Link/LinkExternal";
@@ -14,36 +14,46 @@ interface Props {
   onDismiss?: () => void;
 }
 
-const AccountModal: React.FC<Props> = ({ account, logout, onDismiss = () => null }) => (
-  <Modal title="Your wallet" onDismiss={onDismiss}>
-    <Text
-      fontSize="20px"
-      bold
-      style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", marginBottom: "8px" }}
-    >
-      {account}
-    </Text>
-    <Flex mb="32px">
-      <LinkExternal small href={`https://bscscan.com/address/${account}`} mr="16px">
-        View on BscScan
-      </LinkExternal>
-      <CopyToClipboard toCopy={account}>Copy Address</CopyToClipboard>
-    </Flex>
-    <Flex justifyContent="center">
-      <Button
-        scale="sm"
-        variant="secondary"
-        onClick={() => {
-          logout();
-          window.localStorage.removeItem(connectorLocalStorageKey);
-          window.localStorage.removeItem(ConnectorNames.WalletConnect);
-          onDismiss();
-        }}
+const AccountModal: React.FC<Props> = ({ account, logout, onDismiss = () => null }) => {
+  const clearCache = useCallback(() => {
+    window.localStorage.removeItem(connectorLocalStorageKey);
+    if (window.localStorage.getItem(ConnectorNames.WalletConnect)) {
+      window.localStorage.removeItem(ConnectorNames.WalletConnect);
+      // Reload the webpage to disconnect walletconnect websocket.
+      window.location.reload();
+    }
+  }, []);
+
+  return (
+    <Modal title="Your wallet" onDismiss={onDismiss}>
+      <Text
+        fontSize="20px"
+        bold
+        style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", marginBottom: "8px" }}
       >
-        Logout
-      </Button>
-    </Flex>
-  </Modal>
-);
+        {account}
+      </Text>
+      <Flex mb="32px">
+        <LinkExternal small href={`https://bscscan.com/address/${account}`} mr="16px">
+          View on BscScan
+        </LinkExternal>
+        <CopyToClipboard toCopy={account}>Copy Address</CopyToClipboard>
+      </Flex>
+      <Flex justifyContent="center">
+        <Button
+          scale="sm"
+          variant="secondary"
+          onClick={() => {
+            logout();
+            clearCache();
+            onDismiss();
+          }}
+        >
+          Logout
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
 
 export default AccountModal;

--- a/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
@@ -15,14 +15,14 @@ interface Props {
 }
 
 const AccountModal: React.FC<Props> = ({ account, logout, onDismiss = () => null }) => {
-  const clearCache = useCallback(() => {
+  const clearCache = () => {
     window.localStorage.removeItem(connectorLocalStorageKey);
     if (window.localStorage.getItem(ConnectorNames.WalletConnect)) {
       window.localStorage.removeItem(ConnectorNames.WalletConnect);
       // Reload the webpage to disconnect walletconnect websocket.
       window.location.reload();
     }
-  }, []);
+  };
 
   return (
     <Modal title="Your wallet" onDismiss={onDismiss}>

--- a/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import Button from "../../components/Button/Button";
 import Text from "../../components/Text/Text";
 import LinkExternal from "../../components/Link/LinkExternal";

--- a/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/AccountModal.tsx
@@ -6,6 +6,7 @@ import Flex from "../../components/Box/Flex";
 import { Modal } from "../Modal";
 import CopyToClipboard from "./CopyToClipboard";
 import { connectorLocalStorageKey } from "./config";
+import { ConnectorNames } from "./types";
 
 interface Props {
   account: string;
@@ -35,6 +36,7 @@ const AccountModal: React.FC<Props> = ({ account, logout, onDismiss = () => null
         onClick={() => {
           logout();
           window.localStorage.removeItem(connectorLocalStorageKey);
+          window.localStorage.removeItem(ConnectorNames.WalletConnect);
           onDismiss();
         }}
       >


### PR DESCRIPTION
Fixes https://github.com/pancakeswap/pancake-frontend/issues/1213

If user doesn't end session (kills the app from mobile for example) from the wallet app that used to scan qr and use logout button from our interface, then when user clicks connect and select walletConnect it immediately connects the previous account without asking a new qr code. Actions that need transactions cannot be done but can see stake amount and balance. 

If user wants to login to an another account, it cannot proceed until it clears cache