### PR TITLE
feat(modal-bg): Add overflow hidden prop to Modal container and update storybook

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/modal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/modal.test.tsx
@@ -142,6 +142,7 @@ it("renders correctly", () => {
     }
 
     .c1 {
+      overflow: hidden;
       background: #FFFFFF;
       box-shadow: 0px 20px 36px -8px rgba(14,14,44,0.1),0px 1px 1px rgba(0,0,0,0.05);
       border: 1px solid #E9EAEB;

--- a/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
@@ -311,6 +311,7 @@ it("renders ConnectModal correctly", () => {
     }
 
     .c1 {
+      overflow: hidden;
       background: #FFFFFF;
       box-shadow: 0px 20px 36px -8px rgba(14,14,44,0.1),0px 1px 1px rgba(0,0,0,0.05);
       border: 1px solid #E9EAEB;

--- a/packages/pancake-uikit/src/widgets/Modal/index.stories.tsx
+++ b/packages/pancake-uikit/src/widgets/Modal/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
+import { useTheme } from "styled-components";
 import { Modal, useModal } from ".";
-import { InjectedProps } from "./types";
+import { ModalProps } from "./types";
 import Button from "../../components/Button/Button";
 import Heading from "../../components/Heading/Heading";
 
@@ -10,24 +11,23 @@ export default {
   argTypes: {},
 };
 
-interface CustomModalProps extends InjectedProps {
-  title: string;
-}
-
-const CustomModal: React.FC<CustomModalProps> = ({ title, onDismiss }) => (
-  <Modal title={title} onDismiss={onDismiss}>
+const CustomModal: React.FC<ModalProps> = ({ title, onDismiss, ...props }) => (
+  <Modal title={title} onDismiss={onDismiss} {...props}>
     <Heading>{title}</Heading>
     <Button>This button Does nothing</Button>
   </Modal>
 );
 
 export const Default: React.FC = () => {
+  const theme = useTheme();
   const [onPresent1] = useModal(<CustomModal title="Modal 1" />);
   const [onPresent2] = useModal(<CustomModal title="Modal 2" />);
+  const [onPresent3] = useModal(<CustomModal title="Modal 3" headerBackground={theme.colors.gradients.cardHeader} />);
   return (
     <div>
       <Button onClick={onPresent1}>Open modal 1</Button>
       <Button onClick={onPresent2}>Open modal 2</Button>
+      <Button onClick={onPresent3}>Open modal with background</Button>
     </div>
   );
 };
@@ -42,18 +42,14 @@ export const DisableOverlayClick: React.FC = () => {
   );
 };
 
-interface BackButtonModalProps extends InjectedProps {
-  title: string;
-}
-
-const BackButtonModal: React.FC<BackButtonModalProps> = ({ title, onDismiss }) => {
+const BackButtonModal: React.FC<ModalProps> = ({ title, onDismiss }) => {
   const handleOnBack = () => {
     return 1;
   };
 
   return (
     <Modal title={title} onDismiss={onDismiss} onBack={handleOnBack} hideCloseButton>
-      <Button onClick={onDismiss} variant="text" fullWidth>
+      <Button onClick={onDismiss} variant="text">
         Consumer can still close it.
       </Button>
     </Modal>

--- a/packages/pancake-uikit/src/widgets/Modal/styles.tsx
+++ b/packages/pancake-uikit/src/widgets/Modal/styles.tsx
@@ -40,6 +40,7 @@ export const ModalBackButton: React.FC<{ onBack: ModalProps["onBack"] }> = ({ on
 };
 
 export const ModalContainer = styled(Box)<{ minWidth: string }>`
+  overflow: hidden;
   background: ${({ theme }) => theme.modal.background};
   box-shadow: 0px 20px 36px -8px rgba(14, 14, 44, 0.1), 0px 1px 1px rgba(0, 0, 0, 0.05);
   border: 1px solid ${({ theme }) => theme.colors.borderColor};


### PR DESCRIPTION
Current application of the `background` style to `<ModalHeader/>` mean it blasts over its parent `<ModalContainer/>`'s border radius, resulting in:

<img width="380" alt="Screenshot 2021-04-21 at 11 14 45" src="https://user-images.githubusercontent.com/79279477/115544852-0310df00-a29b-11eb-9724-a4ed695a576b.png">

- Added `overflow: hidden;` to modal container
- Fixed up some proptypes in the Modal story

<img width="408" alt="Screenshot 2021-04-21 at 11 30 02" src="https://user-images.githubusercontent.com/79279477/115544964-2a67ac00-a29b-11eb-9655-9b9b27ed3b98.png">
