### PR TITLE
fix(card-ribbon): Add z-index value to ribbon and spread props to improve flexibility of component

### DIFF
--- a/packages/pancake-uikit/src/components/Card/CardRibbon.tsx
+++ b/packages/pancake-uikit/src/components/Card/CardRibbon.tsx
@@ -7,6 +7,7 @@ interface StyledCardRibbonProps extends CardRibbonProps {
 }
 
 const StyledCardRibbon = styled.div<Partial<StyledCardRibbonProps>>`
+  z-index: 1;
   background-color: ${({ variantColor = "secondary", theme }) => theme.colors[variantColor]};
   color: white;
   margin: 0;
@@ -51,9 +52,9 @@ const StyledCardRibbon = styled.div<Partial<StyledCardRibbonProps>>`
   }
 `;
 
-const CardRibbon: React.FC<CardRibbonProps> = ({ variantColor, text, ribbonPosition }) => {
+const CardRibbon: React.FC<CardRibbonProps> = ({ variantColor, text, ribbonPosition, ...props }) => {
   return (
-    <StyledCardRibbon variantColor={variantColor} ribbonPosition={ribbonPosition}>
+    <StyledCardRibbon variantColor={variantColor} ribbonPosition={ribbonPosition} {...props}>
       <div title={text}>{text}</div>
     </StyledCardRibbon>
   );

--- a/packages/pancake-uikit/src/components/Card/types.ts
+++ b/packages/pancake-uikit/src/components/Card/types.ts
@@ -2,7 +2,7 @@ import { HTMLAttributes } from "react";
 import { SpaceProps } from "styled-system";
 import { Colors } from "../../theme/types";
 
-export interface CardRibbonProps {
+export interface CardRibbonProps extends SpaceProps, HTMLAttributes<HTMLDivElement> {
   variantColor?: keyof Colors;
   text: string;
   ribbonPosition?: "right" | "left";


### PR DESCRIPTION
- Using this component in the new pool cards
- Lack of z-index means with other card header elements it disappears behind them
- Added `...props` spreading to improve utility of component

Sad
<img width="389" alt="Screenshot 2021-04-28 at 18 18 22" src="https://user-images.githubusercontent.com/79279477/116446058-7e036800-a84e-11eb-8564-9f7cfd0cac65.png">

Happy
<img width="395" alt="Screenshot 2021-04-28 at 18 17 53" src="https://user-images.githubusercontent.com/79279477/116446072-8196ef00-a84e-11eb-9271-d04a094a5dd5.png">
