### PR TITLE
[UI Kit] fix(uikit): Unique ids for svgs that use clip path

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/walletModal.test.tsx
@@ -551,7 +551,7 @@ it("renders ConnectModal correctly", () => {
               xmlns="http://www.w3.org/2000/svg"
             >
               <g
-                clip-path="url(#clip-trustwallet)"
+                clip-path="url(#svg1)"
               >
                 <path
                   d="M48.0048 96.0097C74.5172 96.0097 96.0097 74.5172 96.0097 48.0048C96.0097 21.4925 74.5172 0 48.0048 0C21.4925 0 0 21.4925 0 48.0048C0 74.5172 21.4925 96.0097 48.0048 96.0097Z"
@@ -564,7 +564,7 @@ it("renders ConnectModal correctly", () => {
               </g>
               <defs>
                 <clippath
-                  id="clip-trustwallet"
+                  id="svg1"
                 >
                   <rect
                     fill="white"

--- a/packages/pancake-uikit/src/components/Svg/Icons/BunnyCards.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/BunnyCards.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 

--- a/packages/pancake-uikit/src/components/Svg/Icons/BunnyCards.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/BunnyCards.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { uniqueId } from "lodash";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 
 const Icon: React.FC<SvgProps> = (props) => {
+  const id = uniqueId("svg");
+
   return (
     <Svg viewBox="0 0 64 64" {...props}>
-      <g clipPath="url(#clip-bunnycards)">
+      <g clipPath={`url(#${id})`}>
         <rect
           width="32"
           height="40"
@@ -69,7 +72,7 @@ const Icon: React.FC<SvgProps> = (props) => {
         </g>
       </g>
       <defs>
-        <clipPath id="clip-bunnycards">
+        <clipPath id={id}>
           <rect width="64" height="64" fill="white" />
         </clipPath>
       </defs>

--- a/packages/pancake-uikit/src/components/Svg/Icons/PocketWatch.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/PocketWatch.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { uniqueId } from "lodash";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 
 const Icon: React.FC<SvgProps> = (props) => {
+  const id = uniqueId("svg");
+
   return (
     <Svg viewBox="0 0 48 48" {...props}>
-      <g clipPath="url(#clip-pocketwatch)">
+      <g clipPath={`url(#${id})`}>
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -90,7 +93,7 @@ const Icon: React.FC<SvgProps> = (props) => {
         />
       </g>
       <defs>
-        <clipPath id="clip-pocketwatch">
+        <clipPath id={id}>
           <rect width="48" height="48" fill="white" transform="matrix(-1 0 0 1 48 0)" />
         </clipPath>
       </defs>

--- a/packages/pancake-uikit/src/components/Svg/Icons/PocketWatch.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/PocketWatch.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 

--- a/packages/pancake-uikit/src/components/Svg/Icons/TeamPlayer.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/TeamPlayer.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { uniqueId } from "lodash";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 
 const Icon: React.FC<SvgProps> = (props) => {
+  const id = uniqueId("svg");
+
   return (
     <Svg viewBox="0 0 25 25" {...props}>
-      <g clipPath="url(#clip-teamplayer)">
+      <g clipPath={`url(#${id})`}>
         <path
           d="M15.9617 4.03476C16.5597 2.82143 15.6818 1.40061 14.2254 1.22477C13.0389 1.08149 11.9708 1.84428 11.8399 2.9285L11.3896 6.65764C11.2976 7.41951 11.899 8.11875 12.7328 8.21943C13.3889 8.29864 14.0166 7.98162 14.286 7.435L15.9617 4.03476Z"
           fill="#1FC7D4"
@@ -122,7 +125,7 @@ const Icon: React.FC<SvgProps> = (props) => {
         />
       </g>
       <defs>
-        <clipPath id="clip-teamplayer">
+        <clipPath id={id}>
           <rect width="24" height="24" fill="white" transform="translate(0.5 0.5)" />
         </clipPath>
       </defs>

--- a/packages/pancake-uikit/src/components/Svg/Icons/TeamPlayer.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/TeamPlayer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 

--- a/packages/pancake-uikit/src/components/Svg/Icons/Won.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/Won.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { uniqueId } from "lodash";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 
 const Icon: React.FC<SvgProps> = (props) => {
+  const id = uniqueId("svg");
+
   return (
     <Svg viewBox="0 0 64 64" {...props}>
-      <g clipPath="url(#clip-won)">
+      <g clipPath={`url(#${id})`}>
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -95,7 +98,7 @@ const Icon: React.FC<SvgProps> = (props) => {
           <stop stopColor="#53DEE9" />
           <stop offset="1" stopColor="#1FC7D4" />
         </linearGradient>
-        <clipPath id="clip-won">
+        <clipPath id={id}>
           <rect width="64" height="64" fill="white" />
         </clipPath>
       </defs>

--- a/packages/pancake-uikit/src/components/Svg/Icons/Won.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/Won.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import Svg from "../Svg";
 import { SvgProps } from "../types";
 

--- a/packages/pancake-uikit/src/widgets/WalletModal/icons/TrustWallet.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/icons/TrustWallet.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { uniqueId } from "lodash";
 import Svg from "../../../components/Svg/Svg";
 import { SvgProps } from "../../../components/Svg/types";
 
 const Icon: React.FC<SvgProps> = (props) => {
+  const id = uniqueId("svg");
+
   return (
     <Svg viewBox="0 0 96 96" {...props}>
-      <g clipPath="url(#clip-trustwallet)">
+      <g clipPath={`url(#${id})`}>
         <path
           d="M48.0048 96.0097C74.5172 96.0097 96.0097 74.5172 96.0097 48.0048C96.0097 21.4925 74.5172 0 48.0048 0C21.4925 0 0 21.4925 0 48.0048C0 74.5172 21.4925 96.0097 48.0048 96.0097Z"
           fill="#3375BB"
@@ -16,7 +19,7 @@ const Icon: React.FC<SvgProps> = (props) => {
         />
       </g>
       <defs>
-        <clipPath id="clip-trustwallet">
+        <clipPath id={id}>
           <rect width="96" height="96" fill="white" />
         </clipPath>
       </defs>

--- a/packages/pancake-uikit/src/widgets/WalletModal/icons/TrustWallet.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/icons/TrustWallet.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import Svg from "../../../components/Svg/Svg";
 import { SvgProps } from "../../../components/Svg/types";
 


### PR DESCRIPTION
Found an issue where if you were using more than 1 SVG that used `clipPath` than only 1 SVG would be displayed.
