### PR TITLE
fix: Visible Border and background in ios for bunny slider thumb

### DIFF
--- a/packages/pancake-uikit/src/components/Slider/styles.ts
+++ b/packages/pancake-uikit/src/components/Slider/styles.ts
@@ -24,6 +24,8 @@ const getCursorStyle = ({ disabled = false }: DisabledProp) => {
 const getBaseThumbStyles = ({ isMax, disabled }: StyledInputProps) => `
   -webkit-appearance: none;
   background-image: url(${isMax ? bunnyHeadMax : bunnyHeadMain});
+  background-color: transparent;
+  border: 0;
   cursor: ${getCursorStyle};
   width: 24px;
   height: 32px;
@@ -72,15 +74,11 @@ export const StyledInput = styled.input<StyledInputProps>`
   position: relative;
 
   ::-webkit-slider-thumb {
-    -webkit-appearance: none;
     ${getBaseThumbStyles}
   }
 
   ::-moz-range-thumb {
     ${getBaseThumbStyles}
-
-    background-color: transparent;
-    border: 0;
   }
 
   ::-ms-thumb {


### PR DESCRIPTION
Issue: 

<img width="50%" height="50%" src= "https://user-images.githubusercontent.com/2213635/117299646-1023f580-ae79-11eb-8997-b7ea81226629.jpg">

<img width="50%" height="50%"  src= "https://user-images.githubusercontent.com/2213635/117299651-11552280-ae79-11eb-8d9f-81594626ab80.jpg">
