### PR TITLE
feat(text): Add styled system { layout } style to Text

### DIFF
--- a/packages/pancake-uikit/src/components/Heading/Heading.tsx
+++ b/packages/pancake-uikit/src/components/Heading/Heading.tsx
@@ -1,33 +1,33 @@
 import styled from "styled-components";
 import Text from "../Text/Text";
-import { tags, sizes, HeadingProps } from "./types";
+import { tags, scales, HeadingProps } from "./types";
 
 const style = {
-  [sizes.MD]: {
+  [scales.MD]: {
     fontSize: "20px",
     fontSizeLg: "20px",
   },
-  [sizes.LG]: {
+  [scales.LG]: {
     fontSize: "24px",
     fontSizeLg: "24px",
   },
-  [sizes.XL]: {
+  [scales.XL]: {
     fontSize: "32px",
     fontSizeLg: "40px",
   },
-  [sizes.XXL]: {
+  [scales.XXL]: {
     fontSize: "48px",
     fontSizeLg: "64px",
   },
 };
 
 const Heading = styled(Text).attrs({ bold: true })<HeadingProps>`
-  font-size: ${({ size }) => style[size || sizes.MD].fontSize};
+  font-size: ${({ scale }) => style[scale || scales.MD].fontSize};
   font-weight: 600;
   line-height: 1.1;
 
   ${({ theme }) => theme.mediaQueries.lg} {
-    font-size: ${({ size }) => style[size || sizes.MD].fontSizeLg};
+    font-size: ${({ scale }) => style[scale || scales.MD].fontSizeLg};
   }
 `;
 

--- a/packages/pancake-uikit/src/components/Heading/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Heading/index.stories.tsx
@@ -11,10 +11,10 @@ export const Sizes: React.FC = () => {
   return (
     <div>
       <Heading>Default</Heading>
-      <Heading size="md">Size md</Heading>
-      <Heading size="lg">Size lg</Heading>
-      <Heading size="xl">Size xl</Heading>
-      <Heading size="xxl">Size xxl</Heading>
+      <Heading scale="md">Size md</Heading>
+      <Heading scale="lg">Size lg</Heading>
+      <Heading scale="xl">Size xl</Heading>
+      <Heading scale="xxl">Size xxl</Heading>
     </div>
   );
 };

--- a/packages/pancake-uikit/src/components/Heading/index.tsx
+++ b/packages/pancake-uikit/src/components/Heading/index.tsx
@@ -1,2 +1,2 @@
 export { default as Heading } from "./Heading";
-export type { HeadingProps, Sizes as HeadingSizes, Tags as HeadingTags } from "./types";
+export type { HeadingProps, Scales as HeadingScales, Tags as HeadingTags } from "./types";

--- a/packages/pancake-uikit/src/components/Heading/types.ts
+++ b/packages/pancake-uikit/src/components/Heading/types.ts
@@ -7,7 +7,7 @@ export const tags = {
   H6: "h6",
 };
 
-export const sizes = {
+export const scales = {
   MD: "md",
   LG: "lg",
   XL: "xl",
@@ -15,9 +15,9 @@ export const sizes = {
 } as const;
 
 export type Tags = typeof tags[keyof typeof tags];
-export type Sizes = typeof sizes[keyof typeof sizes];
+export type Scales = typeof scales[keyof typeof scales];
 
 export interface HeadingProps {
   as?: Tags;
-  size?: Sizes;
+  scale?: Scales;
 }

--- a/packages/pancake-uikit/src/components/Text/Text.tsx
+++ b/packages/pancake-uikit/src/components/Text/Text.tsx
@@ -1,5 +1,5 @@
 import styled, { DefaultTheme } from "styled-components";
-import { space, typography } from "styled-system";
+import { space, typography, layout } from "styled-system";
 import getThemeValue from "../../util/getThemeValue";
 import { TextProps } from "./types";
 
@@ -21,15 +21,14 @@ const Text = styled.div<TextProps>`
   font-weight: ${({ bold }) => (bold ? 600 : 400)};
   line-height: 1.5;
   ${({ textTransform }) => textTransform && `text-transform: ${textTransform};`}
-  ${({ inline }) => inline && "display: inline;"}
   ${space}
   ${typography}
+  ${layout}
 `;
 
 Text.defaultProps = {
   color: "text",
   small: false,
-  inline: false,
 };
 
 export default Text;

--- a/packages/pancake-uikit/src/components/Text/Text.tsx
+++ b/packages/pancake-uikit/src/components/Text/Text.tsx
@@ -21,6 +21,7 @@ const Text = styled.div<TextProps>`
   font-weight: ${({ bold }) => (bold ? 600 : 400)};
   line-height: 1.5;
   ${({ textTransform }) => textTransform && `text-transform: ${textTransform};`}
+  ${({ inline }) => inline && "display: inline;"}
   ${space}
   ${typography}
 `;
@@ -28,6 +29,7 @@ const Text = styled.div<TextProps>`
 Text.defaultProps = {
   color: "text",
   small: false,
+  inline: false,
 };
 
 export default Text;

--- a/packages/pancake-uikit/src/components/Text/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Text/index.stories.tsx
@@ -52,13 +52,13 @@ export const Default: React.FC = () => {
         with text transform
       </Text>
       <Text textAlign="center">center</Text>
-      <Text inline color="textSubtle" textTransform="uppercase">
+      <Text display="inline" color="textSubtle" textTransform="uppercase">
         Example of{" "}
       </Text>
-      <Text inline bold textTransform="uppercase">
+      <Text display="inline" bold textTransform="uppercase">
         inline{" "}
       </Text>
-      <Text inline color="textSubtle" textTransform="uppercase">
+      <Text display="inline" color="textSubtle" textTransform="uppercase">
         Text
       </Text>
     </div>

--- a/packages/pancake-uikit/src/components/Text/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Text/index.stories.tsx
@@ -52,6 +52,15 @@ export const Default: React.FC = () => {
         with text transform
       </Text>
       <Text textAlign="center">center</Text>
+      <Text inline color="textSubtle" textTransform="uppercase">
+        Example of{" "}
+      </Text>
+      <Text inline bold textTransform="uppercase">
+        inline{" "}
+      </Text>
+      <Text inline color="textSubtle" textTransform="uppercase">
+        Text
+      </Text>
     </div>
   );
 };

--- a/packages/pancake-uikit/src/components/Text/types.ts
+++ b/packages/pancake-uikit/src/components/Text/types.ts
@@ -1,10 +1,9 @@
-import { SpaceProps, TypographyProps } from "styled-system";
+import { LayoutProps, SpaceProps, TypographyProps } from "styled-system";
 
-export interface TextProps extends SpaceProps, TypographyProps {
+export interface TextProps extends SpaceProps, TypographyProps, LayoutProps {
   color?: string;
   fontSize?: string;
   bold?: boolean;
   small?: boolean;
-  inline?: boolean;
   textTransform?: "uppercase" | "lowercase" | "capitalize";
 }

--- a/packages/pancake-uikit/src/components/Text/types.ts
+++ b/packages/pancake-uikit/src/components/Text/types.ts
@@ -5,5 +5,6 @@ export interface TextProps extends SpaceProps, TypographyProps {
   fontSize?: string;
   bold?: boolean;
   small?: boolean;
+  inline?: boolean;
   textTransform?: "uppercase" | "lowercase" | "capitalize";
 }


### PR DESCRIPTION
Recently, I have needed to restyle the `<Text>` component to have the display property: inline, for example when piecing together a single piece of text with different styles:

<img width="194" alt="Screenshot 2021-05-07 at 15 21 23" src="https://user-images.githubusercontent.com/79279477/117464213-58f6af80-af48-11eb-877a-f92bbe131b5c.png">

Or, a `<Balance>` component, preceded by a `~`
<img width="77" alt="Screenshot 2021-05-07 at 15 21 39" src="https://user-images.githubusercontent.com/79279477/117464339-73c92400-af48-11eb-95cc-fdd4e0068295.png">

Both of these examples require a styled component to be initialised, with the required `display` style.

As per CR feedback - I am passing the styled system `{ layout }` styles to our Text component, allowing us to pass this display style as a prop, rather than needing to declare a styled component.

**Breaking changes**
- As `size` is a reserved styled-system `layout` prop, I've renamed this for headings to 'scale' - this matches the sizing props pattern used throughout the codebase (Button, Checkbox, Input, Toggle, Progress, Radio, Tag, Toggle)
- If we are happy with this change, I'll prepare FE & Exchange PRs changing this prop value throughout the codebase.
