### PR TITLE
fix: Chrome blurs logo during scaling animation

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -297,7 +297,7 @@ it("renders correctly", () => {
     }
 
     .c6 .desktop-icon {
-      width: 156px;
+      width: 160px;
       display: none;
     }
 

--- a/packages/pancake-uikit/src/widgets/Menu/components/Logo.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Logo.tsx
@@ -28,7 +28,7 @@ const StyledLink = styled(Link)`
     }
   }
   .desktop-icon {
-    width: 156px;
+    width: 160px;
     display: none;
     ${({ theme }) => theme.mediaQueries.nav} {
       display: block;


### PR DESCRIPTION
Viewport width is 160px and height is 26px, in order to get best results during transform animations we should stick with that ratios.