### PR TITLE
fix: Bunny slider progress width is too small when is leftmost and too big when is rightmost side

### DIFF
--- a/packages/pancake-uikit/src/components/Slider/Slider.tsx
+++ b/packages/pancake-uikit/src/components/Slider/Slider.tsx
@@ -28,7 +28,16 @@ const Slider: React.FC<SliderProps> = ({
 
   const progressPercentage = (value / max) * 100;
   const isMax = value === max;
-  const progressWidth = isMax ? "calc(100% - 16px)" : `${progressPercentage}%`;
+  let progressWidth: string;
+  if (progressPercentage <= 10) {
+    progressWidth = `${progressPercentage + 0.5}%`;
+  } else if (progressPercentage >= 90) {
+    progressWidth = `${progressPercentage - 4}%`;
+  } else if (progressPercentage >= 60) {
+    progressWidth = `${progressPercentage - 2.5}%`;
+  } else {
+    progressWidth = `${progressPercentage}%`;
+  }
   const labelProgress = isMax ? "calc(100% - 12px)" : `${progressPercentage}%`;
   const displayValueLabel = isMax ? "MAX" : valueLabel;
   return (


### PR DESCRIPTION
Before:

<img width="557" alt="Screenshot 2021-05-11 at 17 36 22" src="https://user-images.githubusercontent.com/2213635/117843904-88c2f180-b27f-11eb-8e8d-0f6f6b04331a.png">
<img width="569" alt="Screenshot 2021-05-11 at 17 36 38" src="https://user-images.githubusercontent.com/2213635/117843919-8b254b80-b27f-11eb-9229-58813de94c7a.png">

After:

<img width="670" alt="Screenshot 2021-05-11 at 17 35 27" src="https://user-images.githubusercontent.com/2213635/117844044-a8f2b080-b27f-11eb-9d3f-9b98ae053d0b.png">
<img width="648" alt="Screenshot 2021-05-11 at 17 35 40" src="https://user-images.githubusercontent.com/2213635/117844033-a5f7c000-b27f-11eb-8725-e17f21e1544b.png">



