### PR TITLE
fix(menu): Extend active menu item, check url startsWith

### DIFF
--- a/packages/pancake-uikit/src/widgets/Menu/components/PanelBody.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/PanelBody.tsx
@@ -28,7 +28,6 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
   // Close the menu when a user clicks a link on mobile
   const handleClick = isMobile ? () => pushNav(false) : undefined;
 
-
   return (
     <Container>
       {links.map((entry) => {
@@ -50,11 +49,22 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
               status={entry.status}
               initialOpenState={initialOpenState}
               className={calloutClass}
-              isActive={entry.items.some((item) => item.href === location.pathname || (item.href.length > 1 && location.pathname.startsWith(item.href)))}
+              isActive={entry.items.some(
+                (item) =>
+                  item.href === location.pathname || (item.href.length > 1 && location.pathname.startsWith(item.href))
+              )}
             >
               {isPushed &&
                 entry.items.map((item) => (
-                  <MenuEntry key={item.href} secondary isActive={item.href === location.pathname || (item.href.length > 1 && location.pathname.startsWith(item.href)) } onClick={handleClick}>
+                  <MenuEntry
+                    key={item.href}
+                    secondary
+                    isActive={
+                      item.href === location.pathname ||
+                      (item.href.length > 1 && location.pathname.startsWith(item.href))
+                    }
+                    onClick={handleClick}
+                  >
                     <MenuLink href={item.href}>
                       <LinkLabel isPushed={isPushed}>{item.label}</LinkLabel>
                       {item.status && (
@@ -69,7 +79,17 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
           );
         }
         return (
-          <MenuEntry key={entry.label} isActive={ entry.href === location.pathname || (entry !== undefined && entry.href !== undefined && entry.href.length > 1 && location.pathname.startsWith(entry.href)) } className={calloutClass}>
+          <MenuEntry
+            key={entry.label}
+            isActive={
+              entry.href === location.pathname ||
+              (entry !== undefined &&
+                entry.href !== undefined &&
+                entry.href.length > 1 &&
+                location.pathname.startsWith(entry.href))
+            }
+            className={calloutClass}
+          >
             <MenuLink href={entry.href} onClick={handleClick}>
               {iconElement}
               <LinkLabel isPushed={isPushed}>{entry.label}</LinkLabel>

--- a/packages/pancake-uikit/src/widgets/Menu/components/PanelBody.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/PanelBody.tsx
@@ -28,6 +28,7 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
   // Close the menu when a user clicks a link on mobile
   const handleClick = isMobile ? () => pushNav(false) : undefined;
 
+
   return (
     <Container>
       {links.map((entry) => {
@@ -49,11 +50,11 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
               status={entry.status}
               initialOpenState={initialOpenState}
               className={calloutClass}
-              isActive={entry.items.some((item) => item.href === location.pathname)}
+              isActive={entry.items.some((item) => item.href === location.pathname || (item.href.length > 1 && location.pathname.startsWith(item.href)))}
             >
               {isPushed &&
                 entry.items.map((item) => (
-                  <MenuEntry key={item.href} secondary isActive={item.href === location.pathname} onClick={handleClick}>
+                  <MenuEntry key={item.href} secondary isActive={item.href === location.pathname || (item.href.length > 1 && location.pathname.startsWith(item.href)) } onClick={handleClick}>
                     <MenuLink href={item.href}>
                       <LinkLabel isPushed={isPushed}>{item.label}</LinkLabel>
                       {item.status && (
@@ -68,7 +69,7 @@ const PanelBody: React.FC<Props> = ({ isPushed, pushNav, isMobile, links }) => {
           );
         }
         return (
-          <MenuEntry key={entry.label} isActive={entry.href === location.pathname} className={calloutClass}>
+          <MenuEntry key={entry.label} isActive={ entry.href === location.pathname || (entry !== undefined && entry.href !== undefined && entry.href.length > 1 && location.pathname.startsWith(entry.href)) } className={calloutClass}>
             <MenuLink href={entry.href} onClick={handleClick}>
               {iconElement}
               <LinkLabel isPushed={isPushed}>{entry.label}</LinkLabel>


### PR DESCRIPTION
I noticed that the active state in the menu is not always correct, so now we also check if the location.pathname starts with the href. Also needs to be longer than 1, because of ``/``.

Before:

![image](https://user-images.githubusercontent.com/987947/118516107-4e9d9800-b736-11eb-9b44-a2ee632e4c90.png)

![image](https://user-images.githubusercontent.com/987947/118516114-51988880-b736-11eb-8750-d346034a4220.png)


After:

![image](https://user-images.githubusercontent.com/987947/118516358-8573ae00-b736-11eb-9c3b-ab0b7912bd2f.png)
