### PR TITLE
fix(menu): Improved accessibility

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -821,12 +821,12 @@ it("renders correctly", () => {
             >
               <div
                 class="c12"
-                role="button"
               >
                 <a
                   aria-current="page"
                   class="active"
                   href="/"
+                  role="button"
                 >
                   <svg
                     class="c13"
@@ -889,10 +889,10 @@ it("renders correctly", () => {
               </div>
               <div
                 class="c16"
-                role="button"
               >
                 <a
                   href="/farms"
+                  role="button"
                 >
                   <svg
                     class="c13"
@@ -934,10 +934,10 @@ it("renders correctly", () => {
               </div>
               <div
                 class="c16"
-                role="button"
               >
                 <a
                   href="/syrup"
+                  role="button"
                 >
                   <svg
                     class="c13"
@@ -964,10 +964,10 @@ it("renders correctly", () => {
               </div>
               <div
                 class="c16"
-                role="button"
               >
                 <a
                   href="/lottery"
+                  role="button"
                 >
                   <svg
                     class="c13"
@@ -991,10 +991,10 @@ it("renders correctly", () => {
               </div>
               <div
                 class="c16"
-                role="button"
               >
                 <a
                   href="/nft"
+                  role="button"
                 >
                   <svg
                     class="c13"
@@ -1016,10 +1016,10 @@ it("renders correctly", () => {
               </div>
               <div
                 class="c16"
-                role="button"
               >
                 <a
                   href="/competition"
+                  role="button"
                 >
                   <svg
                     class="c13"

--- a/packages/pancake-uikit/src/widgets/Menu/components/Accordion.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Accordion.tsx
@@ -54,7 +54,7 @@ const Accordion: React.FC<Props> = ({
 
   return (
     <Container>
-      <MenuEntry onClick={handleClick} className={className} isActive={isActive}>
+      <MenuEntry onClick={handleClick} className={className} isActive={isActive} role="button">
         {icon}
         <LinkLabel isPushed={isPushed}>{label}</LinkLabel>
         {status && (

--- a/packages/pancake-uikit/src/widgets/Menu/components/MenuEntry.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/MenuEntry.tsx
@@ -65,7 +65,6 @@ const MenuEntry = styled.div<Props>`
 MenuEntry.defaultProps = {
   secondary: false,
   isActive: false,
-  role: "button",
 };
 
 const LinkStatus = styled(Text)<{ color: keyof Colors }>`

--- a/packages/pancake-uikit/src/widgets/Menu/components/MenuLink.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/MenuLink.tsx
@@ -7,7 +7,7 @@ const MenuLink: React.FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({ href, ...
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const Tag: any = isHttpLink ? "a" : NavLink;
   const props = isHttpLink ? { href } : { to: href };
-  return <Tag {...props} {...otherProps} />;
+  return <Tag role="button" {...props} {...otherProps} />;
 };
 
 export default MenuLink;


### PR DESCRIPTION
The main menu had an issue with the button role, causing screen readers and tools like Vimium to interpret the functionless ``<div>``  wrapper around the menu links as button.

![image](https://user-images.githubusercontent.com/987947/118985854-1ccb4200-b97f-11eb-923e-037b0b33f939.png)

Before (what tools like Vimium see):
![image](https://user-images.githubusercontent.com/987947/118986174-64ea6480-b97f-11eb-903a-eb3dfb5e914a.png)


After:
![image](https://user-images.githubusercontent.com/987947/118986231-73388080-b97f-11eb-93a8-06af5ef352f8.png)

![image](https://user-images.githubusercontent.com/987947/118986200-6ae04580-b97f-11eb-8d83-72d165b1effe.png)
