### PR TITLE
Feat/tooltip portal

### DIFF
--- a/packages/pancake-uikit/package.json
+++ b/packages/pancake-uikit/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.5",
+    "@types/react-dom": "^17.0.5",
     "jest-styled-components": "^7.0.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/StyledTooltip.tsx
@@ -23,7 +23,7 @@ export const StyledTooltip = styled.div`
   line-height: 130%;
   border-radius: 16px;
   max-width: 320px;
-  z-index: 10;
+  z-index: 101;
   background: ${({ theme }) => theme.tooltip.background};
   color: ${({ theme }) => theme.tooltip.text};
   box-shadow: ${({ theme }) => theme.tooltip.boxShadow};

--- a/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/pancake-uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import { ThemeProvider, DefaultTheme } from "styled-components";
 import { light, dark } from "../../theme";
@@ -15,6 +16,8 @@ const invertTheme = (currentTheme: DefaultTheme) => {
   }
   return dark;
 };
+
+const portalRoot = document.getElementById("portal-root");
 
 const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipRefs => {
   const {
@@ -189,9 +192,12 @@ const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipR
       <Arrow ref={setArrowElement} style={styles.arrow} />
     </StyledTooltip>
   );
+
+  const tooltipInPortal = portalRoot ? createPortal(tooltip, portalRoot) : null;
+
   return {
     targetRef: setTargetElement,
-    tooltip,
+    tooltip: tooltipInPortal ?? tooltip,
     tooltipVisible: visible,
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,6 +3581,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^17.0.5":
+  version "17.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.5.tgz#df44eed5b8d9e0b13bb0cd38e0ea6572a1231227"
+  integrity sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@^5.1.6":
   version "5.1.7"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"


### PR DESCRIPTION
Render tooltip component in the Portal by default if `portal-root` is in the DOM, otherwise just return tooltip like previously.

This PR depends on this update - https://github.com/pancakeswap/pancake-frontend/pull/1295