### PR TITLE
feat: Add netlify.toml for token-list redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,9 @@
   to = "/pancakeswap-default.json"
   status = 301
   force = false
+
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,6 @@
   for = "/*"
     [headers.values]
     Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, HEAD, OPTIONS"
+    Access-Control-Allow-Headers = "Accept, Content-Type, Origin"
+    Access-Control-Max-Age = 86400

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  base = "packages/token-lists/"
+  publish = "lists/"
+
+[[redirects]]
+  from = "/"
+  to = "/pancakeswap-default.json"
+  status = 301
+  force = false


### PR DESCRIPTION
This PR adds netlify.toml config file

Since base dir is `packages/token-lists/` all changes in other directories will be ignored

Redirect is in place to redirect from `https://tokens.pancakeswap.finance` to `https://tokens.pancakeswap.finance/pancakeswap-default.json`

Tested on dummy netlify account