### PR TITLE
fix: (Menu) Footer is not visible completely when navigation bar is visible in mobile browsers

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/dropdown.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/dropdown.test.tsx
@@ -23,7 +23,7 @@ it("renders correctly", () => {
       background-color: #FFFFFF;
       box-shadow: 0px 2px 12px -8px rgba(25,19,38,0.1),0px 1px 1px rgba(25,19,38,0.05);
       padding: 16px;
-      max-height: 500px;
+      max-height: 400px;
       overflow-y: auto;
       z-index: 10;
       border-radius: 4px;

--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -546,7 +546,7 @@ it("renders correctly", () => {
       flex-shrink: 0;
       background-color: #FFFFFF;
       width: 0;
-      height: 100vh;
+      height: 100%;
       -webkit-transition: padding-top 0.2s,width 0.2s cubic-bezier(0.4,0,0.2,1);
       transition: padding-top 0.2s,width 0.2s cubic-bezier(0.4,0,0.2,1);
       border-right: 0;

--- a/packages/pancake-uikit/src/components/Dropdown/Dropdown.tsx
+++ b/packages/pancake-uikit/src/components/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ const DropdownContent = styled.div<{ position: Position }>`
   background-color: ${({ theme }) => theme.nav.background};
   box-shadow: ${({ theme }) => theme.shadows.level1};
   padding: 16px;
-  max-height: 500px;
+  max-height: 400px;
   overflow-y: auto;
   z-index: ${({ theme }) => theme.zIndices.dropdown};
   border-radius: ${({ theme }) => theme.radii.small};

--- a/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Panel.tsx
@@ -21,7 +21,7 @@ const StyledPanel = styled.div<{ isPushed: boolean; showMenu: boolean }>`
   flex-shrink: 0;
   background-color: ${({ theme }) => theme.nav.background};
   width: ${({ isPushed }) => (isPushed ? `${SIDEBAR_WIDTH_FULL}px` : 0)};
-  height: 100vh;
+  height: 100%;
   transition: padding-top 0.2s, width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   border-right: ${({ isPushed }) => (isPushed ? "2px solid rgba(133, 133, 133, 0.1)" : 0)};
   z-index: 11;


### PR DESCRIPTION
It is also so hard to change language in safari when clicking the language button mostly activates navigation bar, and in android it is not visible at first glance unless you scroll it

Before: 

https://user-images.githubusercontent.com/2213635/120793941-d3125800-c537-11eb-896b-93201fb34c23.mp4

After:

https://user-images.githubusercontent.com/2213635/120793989-e1607400-c537-11eb-888c-c20ec20c21c3.mp4

==================

It also fixes language selection menu top part is not visible in small screens (it is under the header bar) when in wallet browsers or safari with navigation bar at the bottom.

Before: 

https://user-images.githubusercontent.com/2213635/120794898-191beb80-c539-11eb-9661-04fab75d3bba.mp4

After:

https://user-images.githubusercontent.com/2213635/120795001-3486f680-c539-11eb-9044-a655f126806e.mp4

