### PR TITLE
chore: Update CODEOWNERS config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # review when someone opens a pull request.
 *       @RabbitDoge @hachiojidev @Chef-Chungus
 
-packages/token-lists/ @ChefKai
+packages/token-lists/ @RabbitDoge @hachiojidev @Chef-Chungus @ChefKai


### PR DESCRIPTION
Following #174 pull request updating CODEOWNERS for a specific package, we saw that it removed previous CODEOWNERS from the auto-review, as experienced in #181; this PR aims to add back previous owners.