### PR TITLE
fix: Increase ifo stepper connector height

### DIFF
--- a/packages/pancake-uikit/src/components/Stepper/Step.tsx
+++ b/packages/pancake-uikit/src/components/Stepper/Step.tsx
@@ -23,7 +23,7 @@ const StyledStep = styled(Flex)`
 const Connector = styled.div<StatusProps>`
   position: absolute;
   width: 4px;
-  height: 100%;
+  height: 110%;
   top: 50%;
   left: calc(50% - 2px);
   background-color: ${({ theme, status }) => theme.colors[status === "past" ? "success" : "textDisabled"]};


### PR DESCRIPTION
Go to ifo

Go to how to take part section

See connector bar between steps sometimes not long enough.

![EF15A727-8DA7-445B-87DC-6DA7A9C54B7E](https://user-images.githubusercontent.com/2213635/125300485-bfc28b80-e332-11eb-85b7-d46ae3e119e0.jpeg)


