### PR TITLE
Feature/UI kit improvements

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/balanceinput.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/balanceinput.test.tsx
@@ -29,6 +29,7 @@ it("renders correctly", () => {
       outline: 0;
       padding: 0 16px;
       width: 100%;
+      border: 1px solid #d7caec;
     }
 
     .c1::-webkit-input-placeholder {
@@ -73,6 +74,7 @@ it("renders correctly", () => {
       padding-left: 0;
       padding-right: 0;
       text-align: right;
+      border: none;
     }
 
     .c2::-webkit-input-placeholder {

--- a/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/buttonmenu.test.tsx
@@ -29,6 +29,11 @@ it("renders correctly", () => {
       margin-left: 2px;
     }
 
+    .c0 > button,
+    .c0 a {
+      box-shadow: none;
+    }
+
     .c1 {
       -webkit-align-items: center;
       -webkit-box-align: center;
@@ -86,68 +91,11 @@ it("renders correctly", () => {
     }
 
     .c2 {
-      -webkit-align-items: center;
-      -webkit-box-align: center;
-      -ms-flex-align: center;
-      align-items: center;
-      border: 0;
-      border-radius: 16px;
-      box-shadow: 0px -1px 0px 0px rgba(14,14,44,0.4) inset;
-      cursor: pointer;
-      display: -webkit-inline-box;
-      display: -webkit-inline-flex;
-      display: -ms-inline-flexbox;
-      display: inline-flex;
-      font-family: inherit;
-      font-size: 16px;
-      font-weight: 600;
-      -webkit-box-pack: center;
-      -webkit-justify-content: center;
-      -ms-flex-pack: center;
-      justify-content: center;
-      -webkit-letter-spacing: 0.03em;
-      -moz-letter-spacing: 0.03em;
-      -ms-letter-spacing: 0.03em;
-      letter-spacing: 0.03em;
-      line-height: 1;
-      opacity: 1;
-      outline: 0;
-      -webkit-transition: background-color 0.2s,opacity 0.2s;
-      transition: background-color 0.2s,opacity 0.2s;
-      height: 48px;
-      padding: 0 24px;
-      background-color: #EFF4F5;
-      box-shadow: none;
+      background-color: transparent;
       color: #1FC7D4;
     }
 
-    .c2:hover:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled):not(:active) {
-      opacity: 0.65;
-    }
-
-    .c2:active:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled) {
-      opacity: 0.85;
-      -webkit-transform: translateY(1px);
-      -ms-transform: translateY(1px);
-      transform: translateY(1px);
-      box-shadow: none;
-    }
-
-    .c2:disabled,
-    .c2.pancake-button--disabled {
-      background-color: #E9EAEB;
-      border-color: #E9EAEB;
-      box-shadow: none;
-      color: #BDC2C4;
-      cursor: not-allowed;
-    }
-
-    .c3 {
-      background-color: transparent;
-      color: #7A6EAA;
-    }
-
-    .c3:hover:not(:disabled):not(:active) {
+    .c2:hover:not(:disabled):not(:active) {
       background-color: transparent;
     }
 
@@ -161,7 +109,7 @@ it("renders correctly", () => {
           Item 1
         </button>
         <button
-          class="c2 c3"
+          class="c1 c2"
           scale="md"
         >
           Item 2

--- a/packages/pancake-uikit/src/__tests__/components/input.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/input.test.tsx
@@ -20,6 +20,7 @@ it("renders correctly", () => {
       outline: 0;
       padding: 0 16px;
       width: 100%;
+      border: 1px solid #d7caec;
     }
 
     .c0::-webkit-input-placeholder {

--- a/packages/pancake-uikit/src/components/BalanceInput/BalanceInput.tsx
+++ b/packages/pancake-uikit/src/components/BalanceInput/BalanceInput.tsx
@@ -9,6 +9,7 @@ const BalanceInput: React.FC<BalanceInputProps> = ({
   onUserInput,
   currencyValue,
   inputProps,
+  innerRef,
   isWarning = false,
   decimals = 18,
   ...props
@@ -28,6 +29,7 @@ const BalanceInput: React.FC<BalanceInputProps> = ({
         value={value}
         onChange={handleOnChange}
         placeholder={placeholder}
+        ref={innerRef}
         {...inputProps}
       />
       {currencyValue && (

--- a/packages/pancake-uikit/src/components/BalanceInput/styles.tsx
+++ b/packages/pancake-uikit/src/components/BalanceInput/styles.tsx
@@ -18,6 +18,7 @@ export const StyledInput = styled(Input)`
   padding-left: 0;
   padding-right: 0;
   text-align: right;
+  border: none;
 
   ::placeholder {
     color: ${({ theme }) => theme.colors.textSubtle};

--- a/packages/pancake-uikit/src/components/BalanceInput/types.ts
+++ b/packages/pancake-uikit/src/components/BalanceInput/types.ts
@@ -4,6 +4,7 @@ import { BoxProps } from "../Box";
 export interface BalanceInputProps extends BoxProps {
   value: ReactText;
   onUserInput: (input: string) => void;
+  innerRef?: React.RefObject<HTMLInputElement>;
   currencyValue?: ReactNode;
   placeholder?: string;
   inputProps?: Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "placeholder" | "onChange">;

--- a/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -26,6 +26,11 @@ const StyledButtonMenu = styled.div<StyledButtonMenuProps>`
   & > a + a {
     margin-left: 2px; // To avoid focus shadow overlap
   }
+
+  & > button,
+  & a {
+    box-shadow: none;
+  }
   ${space}
 `;
 

--- a/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -31,6 +31,19 @@ const StyledButtonMenu = styled.div<StyledButtonMenuProps>`
   & a {
     box-shadow: none;
   }
+
+  ${({ disabled, theme, variant }) => {
+    if (disabled) {
+      return `
+        opacity: 0.5;
+
+        & > button:disabled {
+          background-color: transparent;
+          color: ${variant === variants.PRIMARY ? theme.colors.primary : theme.colors.textSubtle};
+        }
+    `;
+    }
+  }}
   ${space}
 `;
 
@@ -39,17 +52,19 @@ const ButtonMenu: React.FC<ButtonMenuProps> = ({
   scale = scales.MD,
   variant = variants.PRIMARY,
   onItemClick,
+  disabled,
   children,
   ...props
 }) => {
   return (
-    <StyledButtonMenu variant={variant} {...props}>
+    <StyledButtonMenu disabled={disabled} variant={variant} {...props}>
       {Children.map(children, (child: ReactElement, index) => {
         return cloneElement(child, {
           isActive: activeIndex === index,
           onClick: onItemClick ? () => onItemClick(index) : undefined,
           scale,
           variant,
+          disabled,
         });
       })}
     </StyledButtonMenu>

--- a/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -43,6 +43,7 @@ const StyledButtonMenu = styled.div<StyledButtonMenuProps>`
         }
     `;
     }
+    return "";
   }}
   ${space}
 `;

--- a/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenuItem.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenuItem.tsx
@@ -23,7 +23,7 @@ const ButtonMenuItem: PolymorphicComponent<ButtonMenuItemProps, "button"> = ({
   ...props
 }: ButtonMenuItemProps) => {
   if (!isActive) {
-    return <InactiveButton forwardedAs={as} variant="tertiary" {...props} />;
+    return <InactiveButton forwardedAs={as} variant={variant} {...props} />;
   }
 
   return <Button as={as} variant={variant} {...props} />;

--- a/packages/pancake-uikit/src/components/ButtonMenu/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/index.stories.tsx
@@ -81,3 +81,47 @@ export const AsLinks: React.FC = () => {
     </Row>
   );
 };
+
+export const DisabledMenu: React.FC = () => {
+  const [index, setIndex] = useState(0);
+  const [index1, setIndex1] = useState(1);
+
+  const handleClick = (newIndex) => setIndex(newIndex);
+  const handleClick1 = (newIndex) => setIndex1(newIndex);
+  return (
+    <>
+      <Row>
+        <ButtonMenu activeIndex={index} onItemClick={handleClick}>
+          <ButtonMenuItem>Button 1</ButtonMenuItem>
+          <ButtonMenuItem>Button 2</ButtonMenuItem>
+          <ButtonMenuItem>Button 3</ButtonMenuItem>
+          <ButtonMenuItem>Button 4</ButtonMenuItem>
+        </ButtonMenu>
+      </Row>
+      <Row>
+        <ButtonMenu disabled activeIndex={index} onItemClick={handleClick}>
+          <ButtonMenuItem>Disabled 1</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 2</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 3</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 4</ButtonMenuItem>
+        </ButtonMenu>
+      </Row>
+      <Row>
+        <ButtonMenu activeIndex={index1} onItemClick={handleClick1} scale="sm" variant="subtle" ml="24px">
+          <ButtonMenuItem>Button 1</ButtonMenuItem>
+          <ButtonMenuItem>Button 2</ButtonMenuItem>
+          <ButtonMenuItem>Button 3</ButtonMenuItem>
+          <ButtonMenuItem>Button 4</ButtonMenuItem>
+        </ButtonMenu>
+      </Row>
+      <Row>
+        <ButtonMenu disabled activeIndex={index1} onItemClick={handleClick1} scale="sm" variant="subtle" ml="24px">
+          <ButtonMenuItem>Disabled 1</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 2</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 3</ButtonMenuItem>
+          <ButtonMenuItem>Disabled 4</ButtonMenuItem>
+        </ButtonMenu>
+      </Row>
+    </>
+  );
+};

--- a/packages/pancake-uikit/src/components/ButtonMenu/types.ts
+++ b/packages/pancake-uikit/src/components/ButtonMenu/types.ts
@@ -10,5 +10,6 @@ export interface ButtonMenuProps extends SpaceProps {
   activeIndex?: number;
   onItemClick?: (index: number) => void;
   scale?: Scale;
+  disabled?: boolean;
   children: React.ReactElement[];
 }

--- a/packages/pancake-uikit/src/components/Input/Input.tsx
+++ b/packages/pancake-uikit/src/components/Input/Input.tsx
@@ -44,6 +44,7 @@ const Input = styled.input<InputProps>`
   outline: 0;
   padding: 0 16px;
   width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.inputSecondary};
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.textSubtle};

--- a/packages/pancake-uikit/src/components/Svg/Icons/Pencil.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/Pencil.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Svg from "../Svg";
+import { SvgProps } from "../types";
+
+const Icon: React.FC<SvgProps> = (props) => {
+  return (
+    <Svg viewBox="0 0 19 19" {...props}>
+      <path
+        d="M0 15.46V18.5C0 18.78 0.22 19 0.5 19H3.54C3.67 19 3.8 18.95 3.89 18.85L14.81 7.94L11.06 4.19L0.15 15.1C0.0500001 15.2 0 15.32 0 15.46ZM17.71 5.04C18.1 4.65 18.1 4.02 17.71 3.63L15.37 1.29C14.98 0.899998 14.35 0.899998 13.96 1.29L12.13 3.12L15.88 6.87L17.71 5.04Z"
+        fill="#1FC7D4"
+      />
+    </Svg>
+  );
+};
+
+export default Icon;

--- a/packages/pancake-uikit/src/components/Svg/index.tsx
+++ b/packages/pancake-uikit/src/components/Svg/index.tsx
@@ -49,6 +49,7 @@ export { default as MinusIcon } from "./Icons/Minus";
 export { default as NoProfileAvatarIcon } from "./Icons/NoProfileAvatar";
 export { default as OpenNewIcon } from "./Icons/OpenNew";
 export { default as PancakesIcon } from "./Icons/Pancakes";
+export { default as PencilIcon } from "./Icons/Pencil";
 export { default as PancakeRoundIcon } from "./Icons/PancakeRound";
 export { default as PocketWatchIcon } from "./Icons/PocketWatch";
 export { default as PlayCircleOutlineIcon } from "./Icons/PlayCircleOutline";


### PR DESCRIPTION
- innerReft for BalanceInput (to auto-focus if needed)
- Pencil icon
- ButtonMenu updated to latest Figma
- Input updated to latest figma (border)
- ButtonMenu now has disabled state (whole ButtonMenu, not just separate buttons) - opacity to 0.5, disables all children and slight modification to disabled children if whole ButtonMenu is disabled (no grey bg color)
- BalanceInput has Input inside which has border now, so had to explicitly set border to none in BalanceInput's Input.