### PR TITLE
styles(message): Message component styling RE icon positioning

### DIFF
--- a/packages/pancake-uikit/src/components/Message/Message.tsx
+++ b/packages/pancake-uikit/src/components/Message/Message.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { variant as systemVariant, space } from "styled-system";
 import { WarningIcon, ErrorIcon } from "../Svg";
+import { Box } from "../Box";
 import { MessageProps } from "./types";
 import variants from "./theme";
 
@@ -17,10 +18,6 @@ const MessageContainer = styled.div<MessageProps>`
   border-radius: 16px;
   border: solid 1px;
 
-  svg {
-    align-self: flex-start;
-  }
-
   ${space}
   ${systemVariant({
     variants,
@@ -31,7 +28,9 @@ const Message: React.FC<MessageProps> = ({ children, variant, ...props }) => {
   const Icon = Icons[variant];
   return (
     <MessageContainer variant={variant} {...props}>
-      <Icon color={variants[variant].borderColor} width="24px" mr="12px" style={{ alignSelf: "center" }} />
+      <Box>
+        <Icon color={variants[variant].borderColor} width="24px" mr="12px" />
+      </Box>
       {children}
     </MessageContainer>
   );


### PR DESCRIPTION
- Removed unused & conflicting svg alignSelf styles
- Wrap icon in Box to make it a block element, defaulting to displaying at the start of the flexed MessageContainer

Design specs for the `Message` component all look like:
<img width="156" alt="Screenshot 2021-07-19 at 09 57 48" src="https://user-images.githubusercontent.com/79279477/126134106-479f9d26-2639-41b9-9681-e54032e379eb.png">

But our previous Message styles apply this:
<img width="132" alt="Screenshot 2021-07-19 at 09 57 14" src="https://user-images.githubusercontent.com/79279477/126134168-d4d00580-60f1-4552-ac2a-3bb65da43e91.png">
