### PR TITLE
Chore/pancake toggle absolute positioning

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
@@ -18,6 +18,7 @@ it("renders correctly", () => {
     }
 
     .c0 .pancakes {
+      position: absolute;
       -webkit-transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
       transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
     }
@@ -109,9 +110,9 @@ it("renders correctly", () => {
     }
 
     .c1:checked + label .pancakes {
-      -webkit-transform: translateX(24px);
-      -ms-transform: translateX(24px);
-      transform: translateX(24px);
+      -webkit-transform: translateX(25px);
+      -ms-transform: translateX(25px);
+      transform: translateX(25px);
     }
 
     .c1:checked + label .pancake:nth-child(1) {
@@ -213,6 +214,7 @@ it("renders correctly scale sm", () => {
     }
 
     .c0 .pancakes {
+      position: absolute;
       -webkit-transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
       transition: 0.6s cubic-bezier(0.175,0.885,0.32,1.275);
     }

--- a/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
@@ -26,8 +26,8 @@ it("renders correctly", () => {
     .c0 .pancake {
       background: #e27c31;
       border-radius: 50%;
-      width: 26px;
-      height: 26px;
+      width: 24px;
+      height: 24px;
       position: absolute;
       -webkit-transition: 0.4s ease;
       transition: 0.4s ease;
@@ -110,9 +110,9 @@ it("renders correctly", () => {
     }
 
     .c1:checked + label .pancakes {
-      -webkit-transform: translateX(25px);
-      -ms-transform: translateX(25px);
-      transform: translateX(25px);
+      -webkit-transform: translateX(24px);
+      -ms-transform: translateX(24px);
+      transform: translateX(24px);
     }
 
     .c1:checked + label .pancake:nth-child(1) {
@@ -222,8 +222,8 @@ it("renders correctly scale sm", () => {
     .c0 .pancake {
       background: #e27c31;
       border-radius: 50%;
-      width: 16px;
-      height: 16px;
+      width: 14px;
+      height: 14px;
       position: absolute;
       -webkit-transition: 0.4s ease;
       transition: 0.4s ease;
@@ -306,9 +306,9 @@ it("renders correctly scale sm", () => {
     }
 
     .c1:checked + label .pancakes {
-      -webkit-transform: translateX(15px);
-      -ms-transform: translateX(15px);
-      transform: translateX(15px);
+      -webkit-transform: translateX(14px);
+      -ms-transform: translateX(14px);
+      transform: translateX(14px);
     }
 
     .c1:checked + label .pancake:nth-child(1) {

--- a/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/pancaketoggle.test.tsx
@@ -109,9 +109,9 @@ it("renders correctly", () => {
     }
 
     .c1:checked + label .pancakes {
-      -webkit-transform: translateX(28px);
-      -ms-transform: translateX(28px);
-      transform: translateX(28px);
+      -webkit-transform: translateX(24px);
+      -ms-transform: translateX(24px);
+      transform: translateX(24px);
     }
 
     .c1:checked + label .pancake:nth-child(1) {
@@ -304,9 +304,9 @@ it("renders correctly scale sm", () => {
     }
 
     .c1:checked + label .pancakes {
-      -webkit-transform: translateX(16px);
-      -ms-transform: translateX(16px);
-      transform: translateX(16px);
+      -webkit-transform: translateX(15px);
+      -ms-transform: translateX(15px);
+      transform: translateX(15px);
     }
 
     .c1:checked + label .pancake:nth-child(1) {

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -61,9 +61,11 @@ const scaleKeyValues = {
   },
 };
 
-const getScale = (property: ScaleKeys) => ({ scale = scales.LG }: PancakeToggleProps) => {
-  return scaleKeyValues[scale][property];
-};
+const getScale =
+  (property: ScaleKeys) =>
+  ({ scale = scales.LG }: PancakeToggleProps) => {
+    return scaleKeyValues[scale][property];
+  };
 
 export const PancakeStack = styled.div<HandleProps>`
   position: relative;

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -4,7 +4,7 @@ import { scales, PancakeToggleProps, HandleProps, InputProps, ScaleKeys } from "
 const scaleKeyValues = {
   sm: {
     pancakeSize: "16px", // The size of a pancake (the handle)
-    travelDistance: "16px", // How far pancakes should travel horizontally
+    travelDistance: "15px", // How far pancakes should travel horizontally
     toggleHeight: "20px", // General Height and
     toggleWidth: "36px", // Width of a toggle box
     pancakeThickness: "1px", // Bottom shadow of a pancake
@@ -23,7 +23,7 @@ const scaleKeyValues = {
   },
   md: {
     pancakeSize: "26px",
-    travelDistance: "28px",
+    travelDistance: "24px",
     toggleHeight: "32px",
     toggleWidth: "56px",
     pancakeThickness: "1.5px",
@@ -61,11 +61,9 @@ const scaleKeyValues = {
   },
 };
 
-const getScale =
-  (property: ScaleKeys) =>
-  ({ scale = scales.LG }: PancakeToggleProps) => {
-    return scaleKeyValues[scale][property];
-  };
+const getScale = (property: ScaleKeys) => ({ scale = scales.LG }: PancakeToggleProps) => {
+  return scaleKeyValues[scale][property];
+};
 
 export const PancakeStack = styled.div<HandleProps>`
   position: relative;

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -3,8 +3,8 @@ import { scales, PancakeToggleProps, HandleProps, InputProps, ScaleKeys } from "
 
 const scaleKeyValues = {
   sm: {
-    pancakeSize: "16px", // The size of a pancake (the handle)
-    travelDistance: "15px", // How far pancakes should travel horizontally
+    pancakeSize: "14px", // The size of a pancake (the handle)
+    travelDistance: "14px", // How far pancakes should travel horizontally
     toggleHeight: "20px", // General Height and
     toggleWidth: "36px", // Width of a toggle box
     pancakeThickness: "1px", // Bottom shadow of a pancake
@@ -22,8 +22,8 @@ const scaleKeyValues = {
     butterSmearTwoRight: "2.5px", // these values adjust the position of it
   },
   md: {
-    pancakeSize: "26px",
-    travelDistance: "25px",
+    pancakeSize: "24px",
+    travelDistance: "24px",
     toggleHeight: "32px",
     toggleWidth: "56px",
     pancakeThickness: "1.5px",
@@ -41,8 +41,8 @@ const scaleKeyValues = {
     butterSmearTwoRight: "3.75px",
   },
   lg: {
-    pancakeSize: "32px",
-    travelDistance: "34px",
+    pancakeSize: "31px",
+    travelDistance: "31px",
     toggleHeight: "40px",
     toggleWidth: "72px",
     pancakeThickness: "2px",

--- a/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
+++ b/packages/pancake-uikit/src/components/PancakeToggle/StyledPancakeToggle.tsx
@@ -23,7 +23,7 @@ const scaleKeyValues = {
   },
   md: {
     pancakeSize: "26px",
-    travelDistance: "24px",
+    travelDistance: "25px",
     toggleHeight: "32px",
     toggleWidth: "56px",
     pancakeThickness: "1.5px",
@@ -74,6 +74,7 @@ export const PancakeStack = styled.div<HandleProps>`
   }
 
   .pancakes {
+    position: absolute;
     transition: 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 


### PR DESCRIPTION
The pancakes in the PancakeToggle are block elements, with a transform applied so that they sit on the correct bit of the slider.

Because of this - they increase their parent elements' width, creating an overflow. 

<img width="385" alt="Screenshot 2021-08-06 at 12 51 07" src="https://user-images.githubusercontent.com/79279477/128506402-169a5a75-d0a1-4535-8d3b-4887bf6a52cf.png">

This is fixed by absolute positioning the pancakes.