### PR TITLE
feat: Update Card component

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/card.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/card.test.tsx
@@ -13,25 +13,33 @@ it("renders correctly", () => {
   expect(asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
       .c0 {
-      background-color: #FFFFFF;
-      border: 0px 2px 12px -8px rgba(25,19,38,0.1),0px 1px 1px rgba(25,19,38,0.05);
+      background: #E7E3EB;
       border-radius: 24px;
-      box-shadow: 0px 2px 12px -8px rgba(25,19,38,0.1),0px 1px 1px rgba(25,19,38,0.05);
       color: #280D5F;
       overflow: hidden;
       position: relative;
-    }
-
-    .c2 {
-      padding: 24px;
+      padding: 1px 1px 3px 1px;
     }
 
     .c1 {
-      background: linear-gradient(111.68deg,#F2ECF2 0%,#E8F2F6 100%);
-      padding: 24px;
+      width: 100%;
+      height: 100%;
+      overflow: inherit;
+      background: #FFFFFF;
+      border-radius: 24px;
     }
 
     .c3 {
+      padding: 24px;
+    }
+
+    .c2 {
+      background: linear-gradient(111.68deg,#F2ECF2 0%,#E8F2F6 100%);
+      border-radius: 24px 24px 0 0;
+      padding: 24px;
+    }
+
+    .c4 {
       border-top: 1px solid #E7E3EB;
       padding: 24px;
     }
@@ -42,17 +50,21 @@ it("renders correctly", () => {
         <div
           class="c1"
         >
-          Header
-        </div>
-        <div
-          class="c2"
-        >
-          Body
-        </div>
-        <div
-          class="c3"
-        >
-          Footer
+          <div
+            class="c2"
+          >
+            Header
+          </div>
+          <div
+            class="c3"
+          >
+            Body
+          </div>
+          <div
+            class="c4"
+          >
+            Footer
+          </div>
         </div>
       </div>
     </DocumentFragment>

--- a/packages/pancake-uikit/src/components/Card/Card.tsx
+++ b/packages/pancake-uikit/src/components/Card/Card.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import StyledCard from "./StyledCard";
+import { StyledCard, StyledCardInner } from "./StyledCard";
 import { CardProps } from "./types";
 
-const Card: React.FC<CardProps> = ({ ribbon, children, ...props }) => {
+const Card: React.FC<CardProps> = ({ ribbon, children, background, ...props }) => {
   return (
     <StyledCard {...props}>
-      {ribbon}
-      {children}
+      <StyledCardInner background={background} hasCustomBorder={!!props.borderBackground}>
+        {ribbon}
+        {children}
+      </StyledCardInner>
     </StyledCard>
   );
 };

--- a/packages/pancake-uikit/src/components/Card/CardHeader.tsx
+++ b/packages/pancake-uikit/src/components/Card/CardHeader.tsx
@@ -8,6 +8,7 @@ export interface CardHeaderProps extends SpaceProps {
 
 const CardHeader = styled.div<CardHeaderProps>`
   background: ${({ theme, variant = "default" }) => theme.card.cardHeaderBackground[variant]};
+  border-radius: ${({ theme }) => `${theme.radii.card} ${theme.radii.card} 0 0`};
   ${space}
 `;
 

--- a/packages/pancake-uikit/src/components/Card/CardRibbon.tsx
+++ b/packages/pancake-uikit/src/components/Card/CardRibbon.tsx
@@ -7,7 +7,7 @@ interface StyledCardRibbonProps extends CardRibbonProps {
 }
 
 const StyledCardRibbon = styled.div<Partial<StyledCardRibbonProps>>`
-  z-index: 1;
+  z-index: 10;
   background-color: ${({ variantColor = "secondary", theme }) => theme.colors[variantColor]};
   color: white;
   margin: 0;

--- a/packages/pancake-uikit/src/components/Card/StyledCard.tsx
+++ b/packages/pancake-uikit/src/components/Card/StyledCard.tsx
@@ -1,6 +1,19 @@
-import styled, { DefaultTheme } from "styled-components";
+import styled, { DefaultTheme, keyframes, css } from "styled-components";
 import { space } from "styled-system";
+import { Box } from "../Box";
 import { CardProps } from "./types";
+
+const PromotedGradient = keyframes`
+  0% {
+    background-position: 50% 0%;
+  }
+  50% {
+    background-position: 50% 100%;
+  }
+  100% {
+    background-position: 50% 0%;
+  }
+`;
 
 interface StyledCardProps extends CardProps {
   theme: DefaultTheme;
@@ -9,32 +22,50 @@ interface StyledCardProps extends CardProps {
 /**
  * Priority: Warning --> Success --> Active
  */
-const getBoxShadow = ({ isActive, isSuccess, isWarning, theme }: StyledCardProps) => {
+const getBorderColor = ({ isActive, isSuccess, isWarning, borderBackground, theme }: StyledCardProps) => {
+  if (borderBackground) {
+    return borderBackground;
+  }
   if (isWarning) {
-    return theme.card.boxShadowWarning;
+    return theme.colors.warning;
   }
 
   if (isSuccess) {
-    return theme.card.boxShadowSuccess;
+    return theme.colors.success;
   }
 
   if (isActive) {
-    return theme.card.boxShadowActive;
+    return `linear-gradient(180deg, ${theme.colors.primaryBright}, ${theme.colors.secondary})`;
   }
 
-  return theme.card.boxShadow;
+  return theme.colors.cardBorder;
 };
 
-const StyledCard = styled.div<StyledCardProps>`
-  background-color: ${({ theme }) => theme.card.background};
-  border: ${({ theme }) => theme.card.boxShadow};
+export const StyledCard = styled.div<StyledCardProps>`
+  background: ${getBorderColor};
   border-radius: ${({ theme }) => theme.radii.card};
-  box-shadow: ${getBoxShadow};
   color: ${({ theme, isDisabled }) => theme.colors[isDisabled ? "textDisabled" : "text"]};
   overflow: hidden;
   position: relative;
 
+  ${({ isActive }) =>
+    isActive &&
+    css`
+      animation: ${PromotedGradient} 3s ease infinite;
+      background-size: 400% 400%;
+    `}
+
+  padding: 1px 1px 3px 1px;
+
   ${space}
+`;
+
+export const StyledCardInner = styled(Box)<{ background?: string; hasCustomBorder: boolean }>`
+  width: 100%;
+  height: 100%;
+  overflow: ${({ hasCustomBorder }) => (hasCustomBorder ? "initial" : "inherit")};
+  background: ${({ theme, background }) => background ?? theme.card.background};
+  border-radius: ${({ theme }) => theme.radii.card};
 `;
 
 StyledCard.defaultProps = {
@@ -43,5 +74,3 @@ StyledCard.defaultProps = {
   isWarning: false,
   isDisabled: false,
 };
-
-export default StyledCard;

--- a/packages/pancake-uikit/src/components/Card/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Card/index.stories.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 /* eslint-disable import/no-unresolved */
 import { Meta } from "@storybook/react/types-6-0";
+import Box from "../Box/Box";
 import Heading from "../Heading/Heading";
 import CardRibbon from "./CardRibbon";
 import UIKitCardHeader from "./CardHeader";
@@ -57,8 +58,38 @@ export const Default: React.FC = () => {
 };
 
 export const CardHeader: React.FC = () => {
+  const theme = useTheme();
+  // This is example how to make card header "overlap" the border.
+  // Seems to be easiest solution that works on all screens and does not rely on absolute positioning trickery
+  const headerHeight = "60px";
+  const customHeadingColor = "#7645D9";
+  const gradientStopPoint = `calc(${headerHeight} + 1px)`;
+  const borderBackground = `linear-gradient(${customHeadingColor} ${gradientStopPoint}, ${theme.colors.cardBorder} ${gradientStopPoint})`;
+
+  // Gradient overlap is also possible, just put the "dividing" gradient first and after that the header gradient
+  const gradientBorderColor = `linear-gradient(transparent ${gradientStopPoint}, ${theme.colors.cardBorder} ${gradientStopPoint}), ${theme.colors.gradients.cardHeader}`;
   return (
     <div style={{ padding: "32px", width: "500px" }}>
+      <Row>
+        <Card borderBackground={borderBackground}>
+          <Box background={customHeadingColor} p="16px" height={headerHeight}>
+            <Heading size="xl" color="white">
+              Custom overlapping Header
+            </Heading>
+          </Box>
+          <CardBody>The border on sides of header is covered</CardBody>
+          <CardFooter>Footer</CardFooter>
+        </Card>
+      </Row>
+      <Row>
+        <Card borderBackground={gradientBorderColor}>
+          <Box background={theme.colors.gradients.cardHeader} p="16px" height={headerHeight}>
+            <Heading size="xl">Gradient overlapping Header</Heading>
+          </Box>
+          <CardBody>The border on sides of header is covered</CardBody>
+          <CardFooter>Footer</CardFooter>
+        </Card>
+      </Row>
       <Row>
         <Card>
           <UIKitCardHeader>
@@ -98,6 +129,17 @@ export const CardHeader: React.FC = () => {
     </div>
   );
 };
+
+export const CustomBackground: React.FC = () => {
+  return (
+    <div style={{ padding: "32px", width: "500px" }}>
+      <Card background="#f0c243" borderBackground="#b88700">
+        <CardBody style={{ height: "150px" }}>Custom background</CardBody>
+      </Card>
+    </div>
+  );
+};
+
 export const Ribbon: React.FC = () => {
   return (
     <div style={{ padding: "32px", width: "500px" }}>

--- a/packages/pancake-uikit/src/components/Card/types.ts
+++ b/packages/pancake-uikit/src/components/Card/types.ts
@@ -29,4 +29,6 @@ export interface CardProps extends SpaceProps, HTMLAttributes<HTMLDivElement> {
   isWarning?: boolean;
   isDisabled?: boolean;
   ribbon?: React.ReactNode;
+  borderBackground?: string;
+  background?: string;
 }


### PR DESCRIPTION
Borders are now the ones we use everywhere
`isActive` is the animated one we have in couple of places
![Screenshot 2021-08-08 at 20 20 47](https://user-images.githubusercontent.com/81824236/128640199-a88a879d-bffa-4c67-a1ea-ec7822ce5d7a.png)
![Screenshot 2021-08-08 at 20 20 54](https://user-images.githubusercontent.com/81824236/128640202-2bf9b36a-e706-4bfa-84b9-f26bfc33c3c1.png)
![Screenshot 2021-08-08 at 20 21 15](https://user-images.githubusercontent.com/81824236/128640204-ce5148e1-5cb7-44bd-988d-88e7aaf046a1.png)
