### PR TITLE
fix: Link of cake price to swap page is broken

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/widgets/menu.test.tsx
@@ -1745,7 +1745,7 @@ it("renders correctly", () => {
               >
                 <a
                   class="c28"
-                  href="https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
+                  href="https://pancakeswap.finance/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
                   target="_blank"
                 >
                   <svg

--- a/packages/pancake-uikit/src/widgets/Menu/components/CakePrice.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/CakePrice.tsx
@@ -24,7 +24,7 @@ const PriceLink = styled.a`
 const CakePrice: React.FC<Props> = ({ cakePriceUsd }) => {
   return cakePriceUsd ? (
     <PriceLink
-      href="https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
+      href="https://pancakeswap.finance/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
       target="_blank"
     >
       <PancakeRoundIcon width="24px" mr="8px" />


### PR DESCRIPTION
To reproduce:

1. Click cake price on the bottom of the menu
2. See the swap page output currency not set to cake