### PR TITLE
fix(uikit): BottomNav

### DIFF
--- a/packages/pancake-uikit/src/components/BottomNav/styles.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/styles.tsx
@@ -6,6 +6,7 @@ const StyledBottomNavItem = styled(Flex)`
   bottom: 0px;
   width: 100%;
   padding: 5px 8px;
+  padding-bottom: env(safe-area-inset-bottom);
   background: ${({ theme }) => theme.colors.backgroundAlt};
   border-top: 1px solid ${({ theme }) => theme.colors.cardBorder};
 `;


### PR DESCRIPTION
When I was scrolling the new home page of pancakeswap on my cellphone, I just noticed that the bottom navbar was not handled well on iPhone:

<img src='https://user-images.githubusercontent.com/1091472/133550488-993b63bc-0eb7-428a-822a-7dd085c34cbe.jpeg' width='200' />

This pull request should fix the problem with [`env()`](https://developer.mozilla.org/en-US/docs/Web/CSS/env()).

<img src='https://user-images.githubusercontent.com/1091472/133550987-9b837666-d964-4c8c-be61-bd4739696b25.jpeg' width='200' />

