### PR TITLE
fix(uikit): DropdownMenu

### DIFF
--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -128,7 +128,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   return (
     <Box ref={isBottomNav ? null : setTargetRef} {...props}>
       <Box ref={isBottomNav ? setTargetRef : null}>{children}</Box>
-      {isBottomNav && isOpen && <StyledOverlay />}
+      {isBottomNav && isOpen && showItemsOnMobile && <StyledOverlay />}
       {hasItems && (
         <StyledDropdownMenu
           style={styles.popper}


### PR DESCRIPTION
I believe that `StyledOverlay ` should not be shown when [`showItemsOnMobile`](https://github.com/pancakeswap/pancake-frontend/blob/ecd69c44e997ad998bca75a6065d8280681d3c5b/src/components/Menu/config/config.ts#L11) is set to `false`.

Currently clicking the `Trade` menu would show an empty overlay which is superfluous in my opinion.

<img src='https://user-images.githubusercontent.com/1091472/133594765-cb62cbe5-d1a1-4d3e-8be7-138f99bdca97.jpeg' width='200' />

Here's how you can reproduce it:

1. open the home page on mobile phone
2. click the `Trade` menu on the bottom