### PR TITLE
fix(menu): Increase timeout on touch devices

### DIFF
--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -68,12 +68,9 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
         }
       } else if (isTouchingTooltipRef) {
         // Don't close the menu immediately so it catches the event
-        setTimeout(
-          () => {
-            setIsOpen(false);
-          },
-          isBottomNav ? 500 : 100
-        );
+        setTimeout(() => {
+          setIsOpen(false);
+        }, 500);
       } else {
         setIsOpen(false);
       }


### PR DESCRIPTION
Increase timeout inside DropdownMenu for all touch devices.
Prevent menu from closing before menuItem click event is catched.