### PR TITLE
fix(Menu): Hide menu bar only when scrolled enough

### DIFF
--- a/packages/pancake-uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/Menu.tsx
@@ -82,7 +82,7 @@ const Menu: React.FC<NavProps> = ({
       }
       // Avoid triggering anything at the bottom because of layout shift
       else if (!isBottomOfPage) {
-        if (currentOffset < refPrevOffset.current) {
+        if (currentOffset < refPrevOffset.current || currentOffset <= MENU_HEIGHT) {
           // Has scroll up
           setShowMenu(true);
         } else {


### PR DESCRIPTION
Keep menu bar visible until user scrolled more than menu bar height, fixes below issue:

![Screen Recording 1400-07-02 at 18 19 53](https://user-images.githubusercontent.com/5238989/134696338-2de0a919-258b-496a-83bd-012e3af1d38e.gif)
