### PR TITLE
fix: iOS bottom nav issue on specifics browsers

### DIFF
--- a/packages/pancake-uikit/src/components/BottomNav/styles.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/styles.tsx
@@ -1,14 +1,17 @@
 import styled from "styled-components";
 import { Flex } from "../Box";
 
-const StyledBottomNavItem = styled(Flex)`
+const StyledBottomNav = styled(Flex)`
   position: fixed;
   bottom: 0px;
   width: 100%;
   padding: 5px 8px;
-  padding-bottom: env(safe-area-inset-bottom);
   background: ${({ theme }) => theme.colors.backgroundAlt};
   border-top: 1px solid ${({ theme }) => theme.colors.cardBorder};
+  padding-bottom: env(safe-area-inset-bottom);
+  html[data-useragent*="TokenPocket_iOS"] & {
+    padding-bottom: 45px;
+  }
 `;
 
-export default StyledBottomNavItem;
+export default StyledBottomNav;


### PR DESCRIPTION
Add fallbacks on some browsers that does not define `safe-area-inset-bottom`