### PR TITLE
fix: Token pocket mobile navigation

### DIFF
--- a/packages/pancake-uikit/src/components/BottomNav/BottomNav.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/BottomNav.tsx
@@ -7,12 +7,13 @@ import { BottomNavProps } from "./types";
 import { NotificationDot } from "../NotificationDot";
 
 const BottomNav: React.FC<BottomNavProps> = ({ items = [], activeItem = "", activeSubItem = "", ...props }) => {
-  const [showOverlay, setShowOverlay] = useState(false);
+  const [menuOpenByIndex, setMenuOpenByIndex] = useState({});
+  const isBottomMenuOpen = Object.values(menuOpenByIndex).reduce((acc, value) => acc || value, false);
   return (
     <>
-      {showOverlay && <StyledOverlay />}
+      {isBottomMenuOpen && <StyledOverlay />}
       <StyledBottomNav justifyContent="space-around" {...props}>
-        {items.map(({ label, items: menuItems, href, icon, showOnMobile = true, showItemsOnMobile = true }) => {
+        {items.map(({ label, items: menuItems, href, icon, showOnMobile = true, showItemsOnMobile = true }, index) => {
           const statusColor = menuItems?.find((menuItem) => menuItem.status !== undefined)?.status?.color;
           return (
             showOnMobile && (
@@ -22,7 +23,8 @@ const BottomNav: React.FC<BottomNavProps> = ({ items = [], activeItem = "", acti
                 isBottomNav
                 activeItem={activeSubItem}
                 showItemsOnMobile={showItemsOnMobile}
-                setShowOverlay={setShowOverlay}
+                setMenuOpenByIndex={setMenuOpenByIndex}
+                index={index}
               >
                 <Box>
                   <NotificationDot show={!!statusColor} color={statusColor}>

--- a/packages/pancake-uikit/src/components/BottomNav/BottomNav.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/BottomNav.tsx
@@ -1,41 +1,46 @@
-import React from "react";
+import React, { useState } from "react";
 import BottomNavItem from "../BottomNavItem";
-import StyledBottomNav from "./styles";
+import StyledBottomNav, { StyledOverlay } from "./styles";
 import { Box } from "../Box";
 import DropdownMenu from "../DropdownMenu/DropdownMenu";
 import { BottomNavProps } from "./types";
 import { NotificationDot } from "../NotificationDot";
 
 const BottomNav: React.FC<BottomNavProps> = ({ items = [], activeItem = "", activeSubItem = "", ...props }) => {
+  const [showOverlay, setShowOverlay] = useState(false);
   return (
-    <StyledBottomNav justifyContent="space-around" {...props}>
-      {items.map(({ label, items: menuItems, href, icon, showOnMobile = true, showItemsOnMobile = true }) => {
-        const statusColor = menuItems?.find((menuItem) => menuItem.status !== undefined)?.status?.color;
-        return (
-          showOnMobile && (
-            <DropdownMenu
-              key={label}
-              items={menuItems}
-              isBottomNav
-              activeItem={activeSubItem}
-              showItemsOnMobile={showItemsOnMobile}
-            >
-              <Box>
-                <NotificationDot show={!!statusColor} color={statusColor}>
-                  <BottomNavItem
-                    href={href}
-                    isActive={href === activeItem}
-                    label={label}
-                    iconName={icon}
-                    showItemsOnMobile={showItemsOnMobile}
-                  />
-                </NotificationDot>
-              </Box>
-            </DropdownMenu>
-          )
-        );
-      })}
-    </StyledBottomNav>
+    <>
+      {showOverlay && <StyledOverlay />}
+      <StyledBottomNav justifyContent="space-around" {...props}>
+        {items.map(({ label, items: menuItems, href, icon, showOnMobile = true, showItemsOnMobile = true }) => {
+          const statusColor = menuItems?.find((menuItem) => menuItem.status !== undefined)?.status?.color;
+          return (
+            showOnMobile && (
+              <DropdownMenu
+                key={label}
+                items={menuItems}
+                isBottomNav
+                activeItem={activeSubItem}
+                showItemsOnMobile={showItemsOnMobile}
+                setShowOverlay={setShowOverlay}
+              >
+                <Box>
+                  <NotificationDot show={!!statusColor} color={statusColor}>
+                    <BottomNavItem
+                      href={href}
+                      isActive={href === activeItem}
+                      label={label}
+                      iconName={icon}
+                      showItemsOnMobile={showItemsOnMobile}
+                    />
+                  </NotificationDot>
+                </Box>
+              </DropdownMenu>
+            )
+          );
+        })}
+      </StyledBottomNav>
+    </>
   );
 };
 

--- a/packages/pancake-uikit/src/components/BottomNav/styles.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/styles.tsx
@@ -14,4 +14,15 @@ const StyledBottomNav = styled(Flex)`
   }
 `;
 
+export const StyledOverlay = styled.div`
+  content: "";
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: ${({ theme }) => `${theme.colors.text}99`};
+  backdrop-filter: blur(2px);
+`;
+
 export default StyledBottomNav;

--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -21,7 +21,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   activeItem = "",
   items = [],
   openMenuTimeout = 0,
-  setShowOverlay,
+  index,
+  setMenuOpenByIndex,
   ...props
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -123,10 +124,10 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   }, [targetRef, tooltipRef, hideTimeout, isHoveringOverTooltip, setIsOpen, openMenuTimeout, isOpen, isBottomNav]);
 
   useEffect(() => {
-    if (setShowOverlay) {
-      setShowOverlay(isOpen);
+    if (setMenuOpenByIndex && index !== undefined) {
+      setMenuOpenByIndex((prevValue) => ({ ...prevValue, [index]: isOpen }));
     }
-  }, [isOpen, setShowOverlay]);
+  }, [isOpen, setMenuOpenByIndex, index]);
 
   return (
     <Box ref={isBottomNav ? null : setTargetRef} {...props}>

--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -11,7 +11,6 @@ import {
   StyledDropdownMenu,
   LinkStatus,
   StyledDropdownMenuItemContainer,
-  StyledOverlay,
 } from "./styles";
 import { DropdownMenuItemType, DropdownMenuProps } from "./types";
 
@@ -22,6 +21,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   activeItem = "",
   items = [],
   openMenuTimeout = 0,
+  setShowOverlay,
   ...props
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -122,10 +122,15 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
     };
   }, [targetRef, tooltipRef, hideTimeout, isHoveringOverTooltip, setIsOpen, openMenuTimeout, isOpen, isBottomNav]);
 
+  useEffect(() => {
+    if (setShowOverlay) {
+      setShowOverlay(isOpen);
+    }
+  }, [isOpen, setShowOverlay]);
+
   return (
     <Box ref={isBottomNav ? null : setTargetRef} {...props}>
       <Box ref={isBottomNav ? setTargetRef : null}>{children}</Box>
-      {isBottomNav && isOpen && showItemsOnMobile && <StyledOverlay />}
       {hasItems && (
         <StyledDropdownMenu
           style={styles.popper}

--- a/packages/pancake-uikit/src/components/DropdownMenu/styles.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/styles.tsx
@@ -59,17 +59,6 @@ export const DropdownMenuDivider = styled.hr`
   margin: 4px 0;
 `;
 
-export const StyledOverlay = styled.div`
-  content: "";
-  position: fixed;
-  top: 0;
-  bottom: 55px;
-  left: 0;
-  right: 0;
-  background-color: ${({ theme }) => `${theme.colors.text}99`};
-  backdrop-filter: blur(2px);
-`;
-
 export const StyledDropdownMenu = styled.div<{ $isOpen: boolean; $isBottomNav: boolean }>`
   background-color: ${({ theme }) => theme.card.background};
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};

--- a/packages/pancake-uikit/src/components/DropdownMenu/types.ts
+++ b/packages/pancake-uikit/src/components/DropdownMenu/types.ts
@@ -8,7 +8,8 @@ export interface DropdownMenuProps extends BoxProps {
   isBottomNav?: boolean;
   openMenuTimeout?: number;
   showItemsOnMobile?: boolean;
-  setShowOverlay: React.Dispatch<React.SetStateAction<boolean>>;
+  index?: number;
+  setMenuOpenByIndex?: React.Dispatch<React.SetStateAction<Record<number, boolean>>>;
 }
 
 export interface StyledDropdownMenuItemProps extends React.ComponentPropsWithoutRef<"button"> {

--- a/packages/pancake-uikit/src/components/DropdownMenu/types.ts
+++ b/packages/pancake-uikit/src/components/DropdownMenu/types.ts
@@ -8,6 +8,7 @@ export interface DropdownMenuProps extends BoxProps {
   isBottomNav?: boolean;
   openMenuTimeout?: number;
   showItemsOnMobile?: boolean;
+  setShowOverlay: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export interface StyledDropdownMenuItemProps extends React.ComponentPropsWithoutRef<"button"> {


### PR DESCRIPTION
Some in-app browser (Token Pocket, Safepal) have navigation issue on mobile, mainly because of the overlay used in BottomNav.
This PR lift up the overlay on the dom structure and ensure that it is always displayed beneath BottomNav.
In order to do that we have to keep track of each menu item state separately because of setTimeout race condition. 