### PR TITLE
fix(uikit): Show active border on SubMenu when hover

### DIFF
--- a/packages/pancake-uikit/src/components/MenuItem/styles.tsx
+++ b/packages/pancake-uikit/src/components/MenuItem/styles.tsx
@@ -16,6 +16,7 @@ export const StyledMenuItemContainer = styled.div<StyledMenuItemProps>`
         width: 100%;
         background-color: ${theme.colors.primary};
         border-radius: 2px 2px 0 0;
+        z-index: 1;
       }
     `};
 `;


### PR DESCRIPTION
![CleanShot 2021-11-18 at 14 34 23](https://user-images.githubusercontent.com/94336009/142364659-6b89359b-3b6a-4a58-a802-cefdaea6b1fd.png)
