### PR TITLE
feat: Add Blocto to wallet options

### DIFF
--- a/packages/pancake-uikit/src/components/Svg/Icons/Blocto.tsx
+++ b/packages/pancake-uikit/src/components/Svg/Icons/Blocto.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Svg from "../Svg";
+import { SvgProps } from "../types";
+
+const Icon: React.FC<SvgProps> = (props) => {
+  return (
+    <Svg viewBox="-10 0 64 62.03" {...props}>
+      <path
+        fill="#afd8f7"
+        d="M95.21,76.12a1.51,1.51,0,0,1,1.49,1.35v.45a22.62,22.62,0,0,1-44.94.34l0-.51v-.27a1.5,1.5,0,0,1,1.49-1.36Z"
+        transform="translate(-51.71 -36.08)"
+      />
+      <path
+        fill="#182a71"
+        d="M52.55,36.08c10.64,0,19.18,8.26,19.18,18.46v18a1.5,1.5,0,0,1-1.5,1.5h-17a1.5,1.5,0,0,1-1.5-1.5V36.92a.83.83,0,0,1,.74-.83Z"
+        transform="translate(-51.71 -36.08)"
+      />
+      <path
+        fill="#3485c4"
+        d="M95.79,68l.11.36-.08-.24a13.75,13.75,0,0,1,.89,3.81,2,2,0,0,1-1.83,2.16H86.14c-5.91,0-10.73-4.18-10.88-10V53.9a1,1,0,0,1,1-1A21.42,21.42,0,0,1,95.79,68Z"
+        transform="translate(-51.71 -36.08)"
+      />
+    </Svg>
+  );
+};
+
+export default Icon;

--- a/packages/pancake-uikit/src/widgets/WalletModal/config.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/config.tsx
@@ -6,6 +6,7 @@ import TokenPocket from "../../components/Svg/Icons/TokenPocket";
 import BinanceChain from "../../components/Svg/Icons/BinanceChain";
 import SafePal from "../../components/Svg/Icons/SafePal";
 import Coin98 from "../../components/Svg/Icons/Coin98";
+import Blocto from "../../components/Svg/Icons/Blocto";
 
 import { Config, ConnectorNames } from "./types";
 
@@ -57,6 +58,12 @@ const connectors: Config[] = [
     title: "Coin98",
     icon: Coin98,
     connectorId: ConnectorNames.Injected,
+    priority: 999,
+  },
+  {
+    title: "Blocto",
+    icon: Blocto,
+    connectorId: ConnectorNames.Blocto,
     priority: 999,
   },
 ];

--- a/packages/pancake-uikit/src/widgets/WalletModal/types.ts
+++ b/packages/pancake-uikit/src/widgets/WalletModal/types.ts
@@ -5,6 +5,7 @@ export enum ConnectorNames {
   Injected = "injected",
   WalletConnect = "walletconnect",
   BSC = "bsc",
+  Blocto = "blocto",
 }
 
 export type Login = (connectorId: ConnectorNames) => void;


### PR DESCRIPTION
Add [Blocto](https://blocto.portto.com) as a wallet option.
Blocto is a cross-platform, cross-chain wallet that can work either in normal browser, with web login experience similar to Fortmatic; and can also work in Blocto wallet app, with injected experience similar to Metamask or Trust wallet.

This PR is required for another PR in pancake-frontend https://github.com/pancakeswap/pancake-frontend/pull/2767

<img width="417" alt="Screen Shot 2021-11-25 at 2 00 15 PM" src="https://user-images.githubusercontent.com/1079990/143388436-8e5c5bdb-ba64-49cc-8c66-cd6353a2eb02.png">

