### PR TITLE
fix(uikit): BottomNav clickoutside

### DIFF
--- a/packages/pancake-uikit/src/components/BottomNav/styles.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/styles.tsx
@@ -12,6 +12,7 @@ const StyledBottomNav = styled(Flex)`
   html[data-useragent*="TokenPocket_iOS"] & {
     padding-bottom: 45px;
   }
+  z-index: 20;
 `;
 
 export const StyledOverlay = styled.div`
@@ -23,6 +24,7 @@ export const StyledOverlay = styled.div`
   right: 0;
   background-color: ${({ theme }) => `${theme.colors.text}99`};
   backdrop-filter: blur(2px);
+  z-index: 20;
 `;
 
 export default StyledBottomNav;

--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -28,7 +28,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   const targetRef = useRef<HTMLDivElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hasItems = items.length > 0;
-  const { styles, attributes } = usePopper(targetRef?.current, tooltipRef.current, {
+  const { styles, attributes } = usePopper(targetRef?.current, tooltipRef?.current, {
     strategy: "fixed",
     placement: isBottomNav ? "top" : "bottom-start",
     modifiers: [{ name: "offset", options: { offset: [0, isBottomNav ? 6 : 0] } }],

--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { usePopper } from "react-popper";
 import { Link } from "react-router-dom";
 import { useOnClickOutside } from "../../hooks";
@@ -25,10 +25,10 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   ...props
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const targetRef = useRef<HTMLDivElement | null>(null);
-  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const [targetRef, setTargetRef] = useState<HTMLDivElement | null>(null);
+  const [tooltipRef, setTooltipRef] = useState<HTMLDivElement | null>(null);
   const hasItems = items.length > 0;
-  const { styles, attributes } = usePopper(targetRef?.current, tooltipRef?.current, {
+  const { styles, attributes } = usePopper(targetRef, tooltipRef, {
     strategy: "fixed",
     placement: isBottomNav ? "top" : "bottom-start",
     modifiers: [{ name: "offset", options: { offset: [0, isBottomNav ? 6 : 0] } }],
@@ -37,23 +37,21 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   const isMenuShow = isOpen && ((isBottomNav && showItemsOnMobile) || !isBottomNav);
 
   useEffect(() => {
-    const targetElement = targetRef.current;
-
     const showDropdownMenu = () => {
       setIsOpen(true);
     };
 
     const hideDropdownMenu = (evt: MouseEvent | TouchEvent) => {
       const target = evt.target as Node;
-      return target && !tooltipRef?.current?.contains(target) && setIsOpen(false);
+      return target && !tooltipRef?.contains(target) && setIsOpen(false);
     };
 
-    targetElement?.addEventListener("mouseenter", showDropdownMenu);
-    targetElement?.addEventListener("mouseleave", hideDropdownMenu);
+    targetRef?.addEventListener("mouseenter", showDropdownMenu);
+    targetRef?.addEventListener("mouseleave", hideDropdownMenu);
 
     return () => {
-      targetElement?.removeEventListener("mouseenter", showDropdownMenu);
-      targetElement?.removeEventListener("mouseleave", hideDropdownMenu);
+      targetRef?.removeEventListener("mouseenter", showDropdownMenu);
+      targetRef?.removeEventListener("mouseleave", hideDropdownMenu);
     };
   }, [targetRef, tooltipRef, setIsOpen, isBottomNav]);
 
@@ -63,12 +61,17 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
     }
   }, [isMenuShow, setMenuOpenByIndex, index]);
 
-  useOnClickOutside(targetRef, () => {
-    setIsOpen(false);
-  });
+  useOnClickOutside(
+    {
+      current: targetRef,
+    },
+    () => {
+      setIsOpen(false);
+    }
+  );
 
   return (
-    <Box ref={targetRef} {...props}>
+    <Box ref={setTargetRef} {...props}>
       <Box
         onPointerDown={() => {
           setIsOpen((s) => !s);
@@ -79,7 +82,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
       {hasItems && (
         <StyledDropdownMenu
           style={styles.popper}
-          ref={tooltipRef}
+          ref={setTooltipRef}
           {...attributes.popper}
           $isBottomNav={isBottomNav}
           $isOpen={isMenuShow}

--- a/packages/pancake-uikit/src/hooks/useOnClickOutside.ts
+++ b/packages/pancake-uikit/src/hooks/useOnClickOutside.ts
@@ -1,6 +1,9 @@
 import { RefObject, useEffect } from "react";
 
-const useOnClickOutside = (ref: RefObject<HTMLElement>, handler: (event?: MouseEvent | TouchEvent) => void): void => {
+const useOnClickOutside = (
+  ref: RefObject<HTMLElement | null>,
+  handler: (event?: MouseEvent | TouchEvent) => void
+): void => {
   useEffect(
     () => {
       const listener = (event: MouseEvent | TouchEvent) => {


### PR DESCRIPTION
in some edge case, `mouseleave` won't trigger on touch mobile
![photo_2021-11-26_10-23-12](https://user-images.githubusercontent.com/94336009/143624888-354c1902-5e21-4387-9d69-102b56627a16.jpg)
