### PR TITLE
fix: (bunnyslider): Remove visible box shadow on slider thumb in mobile safari

### DIFF
--- a/packages/pancake-uikit/src/components/Slider/styles.ts
+++ b/packages/pancake-uikit/src/components/Slider/styles.ts
@@ -25,6 +25,7 @@ const getBaseThumbStyles = ({ isMax, disabled }: StyledInputProps) => `
   -webkit-appearance: none;
   background-image: url(${isMax ? bunnyHeadMax : bunnyHeadMain});
   background-color: transparent;
+  box-shadow: none;
   border: 0;
   cursor: ${getCursorStyle};
   width: 24px;


### PR DESCRIPTION
Currently visible like this in mobile safari

<img width="294" alt="image" src="https://user-images.githubusercontent.com/2213635/146091919-e73e7cd5-b404-4360-9fc3-290bc47b11e8.png">
