### PR TITLE
perf(uikit): Remove backdrop filter

### DIFF
--- a/packages/pancake-uikit/src/__tests__/components/overlay.test.tsx
+++ b/packages/pancake-uikit/src/__tests__/components/overlay.test.tsx
@@ -13,8 +13,6 @@ it("renders correctly", () => {
       width: 100%;
       height: 100%;
       background-color: #280D5F99;
-      -webkit-backdrop-filter: blur(2px);
-      backdrop-filter: blur(2px);
       z-index: 20;
     }
 

--- a/packages/pancake-uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/pancake-uikit/src/components/Overlay/Overlay.tsx
@@ -9,7 +9,6 @@ const StyledOverlay = styled(Box)`
   width: 100%;
   height: 100%;
   background-color: ${({ theme }) => `${theme.colors.text}99`};
-  backdrop-filter: blur(2px);
   z-index: 20;
 `;
 


### PR DESCRIPTION
Remove backdrop filter that impact performance so much, not worth for that
before

https://user-images.githubusercontent.com/94336009/147495299-ff8f1b55-c1bf-4545-b116-1a3ef90e1530.mp4

after

https://user-images.githubusercontent.com/94336009/147495307-e360d12e-dfe3-400e-abae-52b9bad46aaf.mp4


