### PR TITLE
feat: Allow props to be given to dynamic modals via onPresentCallback

### DIFF
--- a/packages/pancake-uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/pancake-uikit/src/widgets/Modal/ModalContext.tsx
@@ -41,17 +41,20 @@ const ModalProvider: React.FC = ({ children }) => {
   const [modalNode, setModalNode] = useState<React.ReactNode>();
   const [nodeId, setNodeId] = useState("");
   const [closeOnOverlayClick, setCloseOnOverlayClick] = useState(true);
+  const [props, setProps] = useState({})
 
-  const handlePresent = (node: React.ReactNode, newNodeId: string) => {
+  const handlePresent = (node: React.ReactNode, newNodeId: string, modalProps: object) => {
     setModalNode(node);
     setIsOpen(true);
     setNodeId(newNodeId);
+    setProps(modalProps)
   };
 
   const handleDismiss = () => {
     setModalNode(undefined);
     setIsOpen(false);
     setNodeId("");
+    setProps({})
   };
 
   const handleOverlayDismiss = () => {
@@ -78,6 +81,7 @@ const ModalProvider: React.FC = ({ children }) => {
           {React.isValidElement(modalNode) &&
             React.cloneElement(modalNode, {
               onDismiss: handleDismiss,
+              ...props,
             })}
         </ModalWrapper>
       )}

--- a/packages/pancake-uikit/src/widgets/Modal/useModal.ts
+++ b/packages/pancake-uikit/src/widgets/Modal/useModal.ts
@@ -10,8 +10,8 @@ const useModal = (
   modalId = "defaultNodeId"
 ): [Handler, Handler] => {
   const { isOpen, nodeId, modalNode, setModalNode, onPresent, onDismiss, setCloseOnOverlayClick } = useContext(Context);
-  const onPresentCallback = useCallback(() => {
-    onPresent(modal, modalId);
+  const onPresentCallback = useCallback((props: object) => {
+    onPresent(modal, modalId, props);
   }, [modal, modalId, onPresent]);
 
   // Updates the "modal" component if props are changed


### PR DESCRIPTION
Your context-based dynamic modal provider is very nice.  There are certain cases however, where it might be nice to call the onPresentCallback with additional props for the modal (only known at runtime).

For example....

```
const { onPresent, onDismiss, isOpen } = useUpgradeModal(handleUpgrade, handleWait)
...
onPresent({ currentVersion: CURRENT_VERSION, newVersion: DEPLOYED_VERSION})
```

The included PR allows props to be passed to the onPresent handler, and then onward to ModalContext

Hope this helps. ;-)

