### PR TITLE
refactor(uikit): Remove react router dom peerDependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
           "src/mocks/**"
         ]
       }
-    ]
+    ],
+    "import/prefer-default-export": 0
   },
   "overrides": [
     {

--- a/packages/pancake-uikit/package.json
+++ b/packages/pancake-uikit/package.json
@@ -31,6 +31,8 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.5",
     "@types/react-dom": "^17.0.5",
+    "@types/lodash": "^4.14.168",
+    "@types/styled-system": "^5.1.10",
     "jest-styled-components": "^7.0.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -40,13 +42,10 @@
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.2.0",
     "styled-components": "^5.2.3"
   },
   "dependencies": {
     "@popperjs/core": "^2.9.2",
-    "@types/lodash": "^4.14.168",
-    "@types/styled-system": "^5.1.10",
     "lodash": "^4.17.20",
     "react-popper": "^2.2.5",
     "styled-system": "^5.1.5"

--- a/packages/pancake-uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
+++ b/packages/pancake-uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
@@ -1176,8 +1176,8 @@ exports[`renders correctly 1`] = `
   -webkit-transform-origin: center 60%;
   -ms-transform-origin: center 60%;
   transform-origin: center 60%;
-  -webkit-animation-name: beoKdG;
-  animation-name: beoKdG;
+  -webkit-animation-name: bEBzQK;
+  animation-name: bEBzQK;
   -webkit-animation-duration: 350ms;
   animation-duration: 350ms;
   -webkit-animation-iteration-count: 1;
@@ -1608,7 +1608,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c12 c13"
-                    href="/https://exchange.pancakeswap.finance"
+                    href="/swap"
                   >
                     Exchange
                   </a>
@@ -1618,7 +1618,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c12 c13"
-                    href="/https://exchange.pancakeswap.finance/#/pool"
+                    href="/liquidity"
                   >
                     Liquidity
                   </a>
@@ -1636,7 +1636,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c9"
-                    href="/"
+                    href="/earn"
                   >
                     Earn
                   </a>
@@ -1651,7 +1651,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c12 c13"
-                    href="/"
+                    href="/earn"
                   >
                     Earn
                   </a>
@@ -1661,7 +1661,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c12 c13"
-                    href="/"
+                    href="/farms"
                   >
                     Yield Farms
                   </a>
@@ -1671,7 +1671,7 @@ exports[`renders correctly 1`] = `
                 >
                   <a
                     class="c12 c13"
-                    href="/"
+                    href="/pools"
                   >
                     Syrup pools
                   </a>
@@ -2219,7 +2219,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="c43"
-              href="/https://exchange.pancakeswap.finance"
+              href="/swap"
             >
               Exchange
             </a>
@@ -2233,7 +2233,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="c43"
-              href="/https://exchange.pancakeswap.finance/#/pool"
+              href="/liquidity"
             >
               Liquidity
             </a>
@@ -2251,7 +2251,7 @@ exports[`renders correctly 1`] = `
           >
             <a
               class="c43"
-              href="/https://exchange.pancakeswap.finance/#/charts"
+              href="/charts"
             >
               <svg
                 class="c46"

--- a/packages/pancake-uikit/src/components/BaseMenu/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/BaseMenu/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter, Link } from "react-router-dom";
 import InlineMenu from "./InlineMenu";
 import SubMenuComp from "./SubMenu";

--- a/packages/pancake-uikit/src/components/BottomNav/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/BottomNav/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import { Box } from "../Box";
 import BottomNav from "./BottomNav";

--- a/packages/pancake-uikit/src/components/BottomNavItem/BottomNavItem.tsx
+++ b/packages/pancake-uikit/src/components/BottomNavItem/BottomNavItem.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useContext } from "react";
+import { MenuContext } from "../../widgets/Menu/context";
 import { Flex } from "../Box";
 import AnimatedIconComponent from "../Svg/AnimatedIconComponent";
 import { StyledBottomNavItem, StyledBottomNavText } from "./styles";
@@ -13,6 +13,7 @@ const BottomNavItem: React.FC<BottomNavItemProps> = ({
   isActive = false,
   ...props
 }) => {
+  const { linkComponent } = useContext(MenuContext);
   const bottomNavItemContent = (
     <Flex flexDirection="column" justifyContent="center" alignItems="center" height="100%">
       {iconName && (
@@ -40,7 +41,7 @@ const BottomNavItem: React.FC<BottomNavItemProps> = ({
       {bottomNavItemContent}
     </StyledBottomNavItem>
   ) : (
-    <StyledBottomNavItem as={Link} to={href} {...props}>
+    <StyledBottomNavItem as={linkComponent} href={href} {...props}>
       {bottomNavItemContent}
     </StyledBottomNavItem>
   );

--- a/packages/pancake-uikit/src/components/BottomNavItem/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/BottomNavItem/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import { Flex } from "../Box";
 import BottomNavItem from "./BottomNavItem";

--- a/packages/pancake-uikit/src/components/Breadcrumbs/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Breadcrumbs/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter, Link as RouterLink } from "react-router-dom";
 import Text from "../Text/Text";
 import Link from "../Link/Link";

--- a/packages/pancake-uikit/src/components/Button/IconButton.tsx
+++ b/packages/pancake-uikit/src/components/Button/IconButton.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
+import { PolymorphicComponent } from "../../util/polymorphic";
 import Button from "./Button";
-import { BaseButtonProps, PolymorphicComponent } from "./types";
+import { BaseButtonProps } from "./types";
 
 const IconButton: PolymorphicComponent<BaseButtonProps, "button"> = styled(Button)<BaseButtonProps>`
   padding: 0;

--- a/packages/pancake-uikit/src/components/Button/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Button/index.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { capitalize } from "lodash";
 import React, { useState } from "react";
 import { BrowserRouter, Link } from "react-router-dom";

--- a/packages/pancake-uikit/src/components/Button/types.ts
+++ b/packages/pancake-uikit/src/components/Button/types.ts
@@ -1,6 +1,6 @@
-import { ComponentProps, ElementType, ReactElement, ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { ElementType, ReactNode } from "react";
 import { LayoutProps, SpaceProps } from "styled-system";
+import type { PolymorphicComponentProps } from "../../util/polymorphic";
 
 export const scales = {
   MD: "md",
@@ -22,23 +22,8 @@ export const variants = {
 export type Scale = typeof scales[keyof typeof scales];
 export type Variant = typeof variants[keyof typeof variants];
 
-/**
- * @see https://www.benmvp.com/blog/polymorphic-react-components-typescript/
- */
-export type AsProps<E extends ElementType = ElementType> = {
-  as?: E;
-};
-
-export type MergeProps<E extends ElementType> = AsProps<E> & Omit<ComponentProps<E>, keyof AsProps>;
-
-export type PolymorphicComponentProps<E extends ElementType, P> = P & MergeProps<E>;
-
-export type PolymorphicComponent<P, D extends ElementType = "button"> = <E extends ElementType = D>(
-  props: PolymorphicComponentProps<E, P>
-) => ReactElement | null;
-
 export interface BaseButtonProps extends LayoutProps, SpaceProps {
-  as?: "a" | "button" | typeof Link;
+  as?: "a" | "button" | ElementType;
   external?: boolean;
   isLoading?: boolean;
   scale?: Scale;

--- a/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenuItem.tsx
+++ b/packages/pancake-uikit/src/components/ButtonMenu/ButtonMenuItem.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+import { PolymorphicComponent } from "../../util/polymorphic";
 import Button from "../Button/Button";
-import { BaseButtonProps, PolymorphicComponent, variants } from "../Button/types";
+import { BaseButtonProps, variants } from "../Button/types";
 import { ButtonMenuItemProps } from "./types";
 
 interface InactiveButtonProps extends BaseButtonProps {

--- a/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { usePopper } from "react-popper";
-import { Link } from "react-router-dom";
 import { useOnClickOutside } from "../../hooks";
+import { MenuContext } from "../../widgets/Menu/context";
 import { Box, Flex } from "../Box";
 import IconComponent from "../Svg/IconComponent";
 import {
@@ -24,6 +24,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   setMenuOpenByIndex,
   ...props
 }) => {
+  const { linkComponent } = useContext(MenuContext);
   const [isOpen, setIsOpen] = useState(false);
   const [targetRef, setTargetRef] = useState<HTMLDivElement | null>(null);
   const [tooltipRef, setTooltipRef] = useState<HTMLDivElement | null>(null);
@@ -111,8 +112,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
                   {type === DropdownMenuItemType.INTERNAL_LINK && (
                     <DropdownMenuItem
                       $isActive={isActive}
-                      as={Link}
-                      to={href}
+                      as={linkComponent}
+                      href={href}
                       onClick={() => {
                         setIsOpen(false);
                       }}

--- a/packages/pancake-uikit/src/components/DropdownMenu/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/DropdownMenu/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import { Box } from "../Box";
 import DropdownMenu from "./DropdownMenu";

--- a/packages/pancake-uikit/src/components/Footer/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/Footer/index.stories.tsx
@@ -1,5 +1,6 @@
 import { noop } from "lodash";
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import { langs, footerLinks } from "./config";
 import Footer from "./Footer";

--- a/packages/pancake-uikit/src/components/MenuItem/MenuItem.tsx
+++ b/packages/pancake-uikit/src/components/MenuItem/MenuItem.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useContext } from "react";
+import { MenuContext } from "../../widgets/Menu/context";
 import StyledMenuItem, { StyledMenuItemContainer } from "./styles";
 import { MenuItemProps } from "./types";
 
@@ -11,10 +11,11 @@ const MenuItem: React.FC<MenuItemProps> = ({
   statusColor,
   ...props
 }) => {
+  const { linkComponent } = useContext(MenuContext);
   const itemLinkProps: unknown = href
     ? {
-        as: Link,
-        to: href,
+        as: linkComponent,
+        href,
       }
     : {
         as: "div",

--- a/packages/pancake-uikit/src/components/MenuItem/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/MenuItem/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import { Flex } from "../Box";
 import MenuItem from "./MenuItem";

--- a/packages/pancake-uikit/src/components/MenuItems/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/MenuItems/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import MenuItems from "./MenuItems";
 import MenuItemsMock from "./mock";

--- a/packages/pancake-uikit/src/components/SubMenuItems/index.stories.tsx
+++ b/packages/pancake-uikit/src/components/SubMenuItems/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserRouter } from "react-router-dom";
 import SubMenuItems from "./SubMenuItems";
 import SubMenuItemsMock from "./mock";

--- a/packages/pancake-uikit/src/util/polymorphic.ts
+++ b/packages/pancake-uikit/src/util/polymorphic.ts
@@ -1,0 +1,16 @@
+import { ComponentProps, ElementType, ReactElement } from "react";
+
+/**
+ * @see https://www.benmvp.com/blog/polymorphic-react-components-typescript/
+ */
+export type AsProps<E extends ElementType = ElementType> = {
+  as?: E;
+};
+
+export type MergeProps<E extends ElementType> = AsProps<E> & Omit<ComponentProps<E>, keyof AsProps>;
+
+export type PolymorphicComponentProps<E extends ElementType, P> = P & MergeProps<E>;
+
+export type PolymorphicComponent<P, D extends ElementType = "button"> = <E extends ElementType = D>(
+  props: PolymorphicComponentProps<E, P>
+) => ReactElement | null;

--- a/packages/pancake-uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/Menu.tsx
@@ -13,6 +13,7 @@ import Logo from "./components/Logo";
 import { MENU_HEIGHT, MOBILE_MENU_HEIGHT, TOP_BANNER_HEIGHT, TOP_BANNER_HEIGHT_MOBILE } from "./config";
 import { NavProps } from "./types";
 import LangSelector from "../../components/LangSelector/LangSelector";
+import { MenuContext } from "./context";
 
 const Wrapper = styled.div`
   position: relative;
@@ -63,6 +64,7 @@ const Inner = styled.div<{ isPushed: boolean; showMenu: boolean }>`
 `;
 
 const Menu: React.FC<NavProps> = ({
+  linkComponent = "a",
   userMenu,
   banner,
   globalMenu,
@@ -124,66 +126,68 @@ const Menu: React.FC<NavProps> = ({
   const subLinksMobileOnly = subLinks?.filter((subLink) => subLink.isMobileOnly);
 
   return (
-    <Wrapper>
-      <FixedContainer showMenu={showMenu} height={totalTopMenuHeight}>
-        {banner && <TopBannerContainer height={topBannerHeight}>{banner}</TopBannerContainer>}
-        <StyledNav>
-          <Flex>
-            <Logo isDark={isDark} href={homeLink?.href ?? "/"} />
-            {!isMobile && <MenuItems items={links} activeItem={activeItem} activeSubItem={activeSubItem} ml="24px" />}
-          </Flex>
-          <Flex alignItems="center" height="100%">
-            {!isMobile && (
-              <Box mr="12px">
-                <CakePrice cakePriceUsd={cakePriceUsd} />
+    <MenuContext.Provider value={{ linkComponent }}>
+      <Wrapper>
+        <FixedContainer showMenu={showMenu} height={totalTopMenuHeight}>
+          {banner && <TopBannerContainer height={topBannerHeight}>{banner}</TopBannerContainer>}
+          <StyledNav>
+            <Flex>
+              <Logo isDark={isDark} href={homeLink?.href ?? "/"} />
+              {!isMobile && <MenuItems items={links} activeItem={activeItem} activeSubItem={activeSubItem} ml="24px" />}
+            </Flex>
+            <Flex alignItems="center" height="100%">
+              {!isMobile && (
+                <Box mr="12px">
+                  <CakePrice cakePriceUsd={cakePriceUsd} />
+                </Box>
+              )}
+              <Box mt="4px">
+                <LangSelector
+                  currentLang={currentLang}
+                  langs={langs}
+                  setLang={setLang}
+                  buttonScale="xs"
+                  color="textSubtle"
+                  hideLanguage
+                />
               </Box>
-            )}
-            <Box mt="4px">
-              <LangSelector
-                currentLang={currentLang}
-                langs={langs}
-                setLang={setLang}
-                buttonScale="xs"
-                color="textSubtle"
-                hideLanguage
-              />
-            </Box>
-            {globalMenu} {userMenu}
-          </Flex>
-        </StyledNav>
-      </FixedContainer>
-      {subLinks && (
-        <Flex justifyContent="space-around">
-          <SubMenuItems items={subLinksWithoutMobile} mt={`${totalTopMenuHeight + 1}px`} activeItem={activeSubItem} />
+              {globalMenu} {userMenu}
+            </Flex>
+          </StyledNav>
+        </FixedContainer>
+        {subLinks && (
+          <Flex justifyContent="space-around">
+            <SubMenuItems items={subLinksWithoutMobile} mt={`${totalTopMenuHeight + 1}px`} activeItem={activeSubItem} />
 
-          {subLinksMobileOnly?.length > 0 && (
-            <SubMenuItems
-              items={subLinksMobileOnly}
-              mt={`${totalTopMenuHeight + 1}px`}
-              activeItem={activeSubItem}
-              isMobileOnly
+            {subLinksMobileOnly?.length > 0 && (
+              <SubMenuItems
+                items={subLinksMobileOnly}
+                mt={`${totalTopMenuHeight + 1}px`}
+                activeItem={activeSubItem}
+                isMobileOnly
+              />
+            )}
+          </Flex>
+        )}
+        <BodyWrapper mt={!subLinks ? `${totalTopMenuHeight + 1}px` : "0"}>
+          <Inner isPushed={false} showMenu={showMenu}>
+            {children}
+            <Footer
+              items={footerLinks}
+              isDark={isDark}
+              toggleTheme={toggleTheme}
+              langs={langs}
+              setLang={setLang}
+              currentLang={currentLang}
+              cakePriceUsd={cakePriceUsd}
+              buyCakeLabel={buyCakeLabel}
+              mb={[`${MOBILE_MENU_HEIGHT}px`, null, "0px"]}
             />
-          )}
-        </Flex>
-      )}
-      <BodyWrapper mt={!subLinks ? `${totalTopMenuHeight + 1}px` : "0"}>
-        <Inner isPushed={false} showMenu={showMenu}>
-          {children}
-          <Footer
-            items={footerLinks}
-            isDark={isDark}
-            toggleTheme={toggleTheme}
-            langs={langs}
-            setLang={setLang}
-            currentLang={currentLang}
-            cakePriceUsd={cakePriceUsd}
-            buyCakeLabel={buyCakeLabel}
-            mb={[`${MOBILE_MENU_HEIGHT}px`, null, "0px"]}
-          />
-        </Inner>
-      </BodyWrapper>
-      {isMobile && <BottomNav items={links} activeItem={activeItem} activeSubItem={activeSubItem} />}
-    </Wrapper>
+          </Inner>
+        </BodyWrapper>
+        {isMobile && <BottomNav items={links} activeItem={activeItem} activeSubItem={activeSubItem} />}
+      </Wrapper>
+    </MenuContext.Provider>
   );
 };
 

--- a/packages/pancake-uikit/src/widgets/Menu/components/Logo.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/components/Logo.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { Link } from "react-router-dom";
+import React, { useContext } from "react";
 import styled, { keyframes } from "styled-components";
 import Flex from "../../../components/Box/Flex";
 import { LogoIcon, LogoWithTextIcon } from "../../../components/Svg";
+import { MenuContext } from "../context";
 
 interface Props {
   isDark: boolean;
@@ -10,11 +10,11 @@ interface Props {
 }
 
 const blink = keyframes`
-  0%,  100% { transform: scaleY(1); } 
-  50% { transform:  scaleY(0.1); } 
+  0%,  100% { transform: scaleY(1); }
+  50% { transform:  scaleY(0.1); }
 `;
 
-const StyledLink = styled(Link)`
+const StyledLink = styled("a")`
   display: flex;
   align-items: center;
   .mobile-icon {
@@ -45,6 +45,7 @@ const StyledLink = styled(Link)`
 `;
 
 const Logo: React.FC<Props> = ({ isDark, href }) => {
+  const { linkComponent } = useContext(MenuContext);
   const isAbsoluteUrl = href.startsWith("http");
   const innerLogo = (
     <>
@@ -60,7 +61,7 @@ const Logo: React.FC<Props> = ({ isDark, href }) => {
           {innerLogo}
         </StyledLink>
       ) : (
-        <StyledLink to={href} aria-label="Pancake home page">
+        <StyledLink href={href} as={linkComponent} aria-label="Pancake home page">
           {innerLogo}
         </StyledLink>
       )}

--- a/packages/pancake-uikit/src/widgets/Menu/config.ts
+++ b/packages/pancake-uikit/src/widgets/Menu/config.ts
@@ -26,15 +26,15 @@ export const links: MenuItemsType[] = [
     items: [
       {
         label: "Exchange",
-        href: "https://exchange.pancakeswap.finance",
+        href: "/swap",
       },
       {
         label: "Liquidity",
-        href: "https://exchange.pancakeswap.finance/#/pool",
+        href: "/liquidity",
       },
       {
         label: "Charts",
-        href: "https://exchange.pancakeswap.finance/#/charts",
+        href: "/charts",
         iconName: "Chart",
         isMobileOnly: true,
       },
@@ -42,20 +42,20 @@ export const links: MenuItemsType[] = [
   },
   {
     label: "Earn",
-    href: "/",
+    href: "/earn",
     icon: "Earn",
     items: [
       {
         label: "Earn",
-        href: "/",
+        href: "/earn",
       },
       {
         label: "Yield Farms",
-        href: "/",
+        href: "/farms",
       },
       {
         label: "Syrup pools",
-        href: "/",
+        href: "/pools",
       },
     ],
   },

--- a/packages/pancake-uikit/src/widgets/Menu/context.ts
+++ b/packages/pancake-uikit/src/widgets/Menu/context.ts
@@ -1,0 +1,3 @@
+import { createContext, ElementType } from "react";
+
+export const MenuContext = createContext<{ linkComponent: ElementType }>({ linkComponent: "a" });

--- a/packages/pancake-uikit/src/widgets/Menu/index.stories.tsx
+++ b/packages/pancake-uikit/src/widgets/Menu/index.stories.tsx
@@ -1,6 +1,7 @@
 import noop from "lodash/noop";
 import React, { useState } from "react";
-import { BrowserRouter, MemoryRouter } from "react-router-dom";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { BrowserRouter, Link, MemoryRouter } from "react-router-dom";
 import Box from "../../components/Box/Box";
 import Flex from "../../components/Box/Flex";
 import Button from "../../components/Button/Button";
@@ -73,6 +74,9 @@ const GlobalMenuComponent: React.FC = () => {
 };
 
 const defaultProps = {
+  linkComponent: ({ href, ...props }) => {
+    return <Link to={href} {...props} />;
+  },
   account: "0xbdda50183d817c3289f895a4472eb475967dc980",
   login: noop,
   logout: noop,

--- a/packages/pancake-uikit/src/widgets/Menu/types.ts
+++ b/packages/pancake-uikit/src/widgets/Menu/types.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { ElementType, ReactElement } from "react";
 import { FooterLinkType } from "../../components/Footer/types";
 import { MenuItemsType } from "../../components/MenuItems/types";
 import { SubMenuItemsType } from "../../components/SubMenuItems/types";
@@ -16,6 +16,7 @@ export interface LinkStatus {
 }
 
 export interface NavProps {
+  linkComponent?: ElementType;
   userMenu?: ReactElement;
   banner?: ReactElement;
   globalMenu?: ReactElement;


### PR DESCRIPTION
This contains Breaking Changes:
Menu component must provider `linkComponent` if using react router, default will be a normal `a` tag

```jsx
// react router
import { Link } from 'react-router-dom'
  linkComponent: ({ href, ...props }) => {
    return <Link to={href} {...props} />;
  }

// nextjs
import Link from 'next/link'
  linkComponent: ({ href, ...props }) => {
    return <Link href={href} {...props} />;
  },
```