### PR TITLE
fix(uikit): Chrome scrollbar layoutshift

### DIFF
--- a/packages/pancake-uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
+++ b/packages/pancake-uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
@@ -2819,6 +2819,36 @@ exports[`renders correctly 1`] = `
                     Français
                   </a>
                   <a
+                    aria-label="Datch"
+                    class="c29 c62"
+                    color="textSubtle"
+                    href="https://t.me/PancakeSwap_DE"
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    Datch
+                  </a>
+                  <a
+                    aria-label="Filipino"
+                    class="c29 c62"
+                    color="textSubtle"
+                    href="https://t.me/Pancakeswap_Ph"
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    Filipino
+                  </a>
+                  <a
+                    aria-label="ქართული ენა"
+                    class="c29 c62"
+                    color="textSubtle"
+                    href="https://t.me/PancakeSwapGeorgia"
+                    rel="noreferrer noopener"
+                    target="_blank"
+                  >
+                    ქართული ენა
+                  </a>
+                  <a
                     aria-label="Announcements"
                     class="c29 c62"
                     color="textSubtle"
@@ -2827,16 +2857,6 @@ exports[`renders correctly 1`] = `
                     target="_blank"
                   >
                     Announcements
-                  </a>
-                  <a
-                    aria-label="Whale Alert"
-                    class="c29 c62"
-                    color="textSubtle"
-                    href="https://t.me/PancakeSwapWhales"
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    Whale Alert
                   </a>
                 </div>
               </div>

--- a/packages/pancake-uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/pancake-uikit/src/components/Overlay/Overlay.tsx
@@ -14,9 +14,15 @@ const StyledOverlay = styled(Box)`
 
 const BodyLock = () => {
   useEffect(() => {
+    document.body.style.cssText = `
+      overflow: hidden;
+    `;
     document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = "visible";
+      document.body.style.cssText = `
+        overflow: visible;
+        overflow: overlay;
+      `;
     };
   }, []);
 


### PR DESCRIPTION
it's not recommend to use `overflow: overlay;`, still it's the only solution to workaround the layout shift on scrollbar.
we can remove this hack after this is working as expected https://github.com/pancakeswap/pancake-frontend/pull/2910