### PR TITLE
fix(uikit): Update the readme to point to the new package

### DIFF
--- a/packages/pancake-uikit/README.md
+++ b/packages/pancake-uikit/README.md
@@ -1,12 +1,15 @@
 # 🥞 Pancake UIkit
 
-[![Version](https://img.shields.io/npm/v/@pancakeswap-libs/uikit)](https://www.npmjs.com/package/@pancakeswap-libs/uikit) [![Size](https://img.shields.io/bundlephobia/min/@pancakeswap-libs/uikit)](https://www.npmjs.com/package/@pancakeswap-libs/uikit)
+[![Version](https://img.shields.io/npm/v/@pancakeswap/uikit)](https://www.npmjs.com/package/@pancakeswap/uikit) [![Size](https://img.shields.io/bundlephobia/min/@pancakeswap/uikit)](https://www.npmjs.com/package/@pancakeswap/uikit)
 
 Pancake UIkit is a set of React components and hooks used to build pages on Pancake's apps. It also contains a theme file for dark and light mode.
 
 ## Install
 
-`yarn add @pancakeswap-libs/uikit`
+`yarn add @pancakeswap/uikit`
+
+***Note**: In case you want to use the older version of the Pancake UIkit, you should install @pancakeswap-libs/uikit, instead, but we recommend using the latest version of the UIkit.*
+
 
 ## Setup
 
@@ -16,7 +19,7 @@ Before using Pancake UIkit, you need to provide the theme file to styled-compone
 
 ```
 import { ThemeProvider } from 'styled-components'
-import { light, dark } from '@pancakeswap-libs/uikit'
+import { light, dark } from '@pancakeswap/uikit'
 ...
 <ThemeProvider theme={isDark}>...</ThemeProvider>
 ```
@@ -26,7 +29,7 @@ import { light, dark } from '@pancakeswap-libs/uikit'
 A reset CSS is available as a global styled component.
 
 ```
-import { ResetCSS } from '@pancakeswap-libs/uikit'
+import { ResetCSS } from '@pancakeswap/uikit'
 ...
 <ResetCSS />
 ```


### PR DESCRIPTION
[ ] Explain what your PR does
I have updated the readme file to point to the correct pancakeswap uikit npm package, it was using the older version which can be a bit confusing for people that wants to use the latest version. A note with the old name has been added too.