### PR TITLE
feat(token-list): update the btt token info

### DIFF
--- a/packages/pancake-uikit/src/components/Image/tokens.ts
+++ b/packages/pancake-uikit/src/components/Image/tokens.ts
@@ -1191,7 +1191,7 @@ const tokens = {
     projectLink: "https://lympo.io/lmt/",
   },
   btt: {
-    symbol: "BTT",
+    symbol: "BTTOLD",
     address: {
       56: "0x8595F9dA7b868b1822194fAEd312235E43007b49",
       97: "",

--- a/packages/token-lists/lists/pancakeswap-top-100.json
+++ b/packages/token-lists/lists/pancakeswap-top-100.json
@@ -1,10 +1,10 @@
 {
   "name": "PancakeSwap Top 100",
-  "timestamp": "2022-01-26T18:35:22.266Z",
+  "timestamp": "2022-02-09T15:35:22.266Z",
   "version": {
     "major": 2,
     "minor": 16,
-    "patch": 10
+    "patch": 11
   },
   "logoURI": "https://assets.trustwalletapp.com/blockchains/smartchain/assets/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82/logo.png",
   "keywords": [
@@ -149,8 +149,8 @@
       "logoURI": "https://tokens.pancakeswap.finance/images/0x5A3010d4d8D3B5fB49f8B6E57FB9E48063f16700.png"
     },
     {
-      "name": "BitTorrent",
-      "symbol": "BTT",
+      "name": "BitTorrent Old",
+      "symbol": "BTTOLD",
       "address": "0x8595F9dA7b868b1822194fAEd312235E43007b49",
       "chainId": 56,
       "decimals": 18,

--- a/packages/token-lists/src/tokens/pancakeswap-top-100.json
+++ b/packages/token-lists/src/tokens/pancakeswap-top-100.json
@@ -200,8 +200,8 @@
     "logoURI": "https://assets.trustwalletapp.com/blockchains/smartchain/assets/0xAD86d0E9764ba90DDD68747D64BFfBd79879a238/logo.png"
   },
   {
-    "name": "BitTorrent",
-    "symbol": "BTT",
+    "name": "BitTorrent Old",
+    "symbol": "BTTOLD",
     "address": "0x8595F9dA7b868b1822194fAEd312235E43007b49",
     "chainId": 56,
     "decimals": 18,


### PR DESCRIPTION
Update the old btt token name to BTTOLD.

[x] Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-uikit/blob/master/CONTRIBUTING.md) first
[x] If your PR is work in progress, open it as `draft`
[x] Before requesting a review, all the checks need to pass
[x] Explain what your PR does

After review, we found that the old BTT token was also included in the "pancakeswap-top-100.json" list, but the token name is not correct. so we raised a new PR to change the token name of old BTT as BTTOLD,  as a continuation of https://github.com/pancakeswap/pancake-toolkit/pull/401 

Otherwise, it may confuse the users, please help to review and merge it, thanks. 