### PR TITLE
fix: Blocto wallet connector name should be injected

### DIFF
--- a/packages/pancake-uikit/src/widgets/WalletModal/config.tsx
+++ b/packages/pancake-uikit/src/widgets/WalletModal/config.tsx
@@ -63,7 +63,7 @@ const connectors: Config[] = [
   {
     title: "Blocto",
     icon: Blocto,
-    connectorId: ConnectorNames.Blocto,
+    connectorId: ConnectorNames.Injected,
     priority: 999,
   },
 ];

--- a/packages/pancake-uikit/src/widgets/WalletModal/types.ts
+++ b/packages/pancake-uikit/src/widgets/WalletModal/types.ts
@@ -5,7 +5,6 @@ export enum ConnectorNames {
   Injected = "injected",
   WalletConnect = "walletconnect",
   BSC = "bsc",
-  Blocto = "blocto",
 }
 
 export type Login = (connectorId: ConnectorNames) => void;


### PR DESCRIPTION
Since it is a injected wallet we don't need to add another connector name. Otherwise it will break the build on frontend when we bump up the uikit version