### PR TITLE
fix: Yarn postinstall workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format:check": "lerna run format:check",
     "storybook:build": "lerna run storybook:build",
     "release": "yarn build && yarn lerna publish",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "lerna run postinstall"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",


### PR DESCRIPTION
`postinstall` on token list doesn't trigger on workspace
Related to #438 